### PR TITLE
ndk-build: Point CXX_<triple> to <triple>-clang++ from the ndk

### DIFF
--- a/ndk-build/src/cargo.rs
+++ b/ndk-build/src/cargo.rs
@@ -7,8 +7,9 @@ pub fn cargo_apk(ndk: &Ndk, target: Target, sdk_version: u32) -> Result<Command,
     let triple = target.rust_triple();
     let mut cargo = Command::new("cargo");
 
-    let clang = ndk.clang(target, sdk_version)?;
+    let (clang, clang_pp) = ndk.clang(target, sdk_version)?;
     cargo.env(format!("CC_{}", triple), &clang);
+    cargo.env(format!("CXX_{}", triple), &clang_pp);
     cargo.env(cargo_env_target_cfg("LINKER", triple), &clang);
 
     let ar = ndk.toolchain_bin("ar", target)?;


### PR DESCRIPTION
Cross-compiling with build.rs using cc::Build and .use_cpp(true) (for
example) invokes <triple>-clang++ which is usually not on PATH or known
to point to the correct NDK. Set the CXX env var for the requested
triple to ensure the right C++ compiler is available and used.

---

Path logic remains in `fn clang`to do the same `exists()` check there. Let me know if this way of formatting and changing the name is the right way around.