### PR TITLE
support <meta-data> tags in manifest

### DIFF
--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -31,6 +31,13 @@ impl ApkConfig {
             .into_iter()
             .map(Into::into)
             .collect();
+        let application_metadatas = metadata
+            .application_metadatas
+            .unwrap_or_default()
+            .into_iter()
+            .map(Into::into)
+            .collect();
+
         let manifest = Manifest {
             package_name: config.package_name,
             package_label: config.package_label,
@@ -46,6 +53,7 @@ impl ApkConfig {
             permissions,
             icon: metadata.icon,
             fullscreen: metadata.fullscreen.unwrap_or(false),
+            application_metadatas,
         };
         Self {
             ndk: config.ndk,

--- a/ndk-build/src/config.rs
+++ b/ndk-build/src/config.rs
@@ -1,4 +1,4 @@
-use crate::manifest::{Feature, Permission};
+use crate::manifest::{ApplicationMetadata, Feature, Permission};
 use crate::ndk::Ndk;
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -27,6 +27,7 @@ pub struct Metadata {
     pub opengles_version: Option<(u8, u8)>,
     pub feature: Option<Vec<FeatureConfig>>,
     pub permission: Option<Vec<PermissionConfig>>,
+    pub application_metadatas: Option<Vec<ApplicationMetadataConfig>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -55,6 +56,21 @@ impl From<PermissionConfig> for Permission {
         Self {
             name: config.name,
             max_sdk_version: config.max_sdk_version,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ApplicationMetadataConfig {
+    name: String,
+    value: String,
+}
+
+impl From<ApplicationMetadataConfig> for ApplicationMetadata {
+    fn from(config: ApplicationMetadataConfig) -> Self {
+        Self {
+            name: config.name,
+            value: config.value,
         }
     }
 }

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -19,6 +19,7 @@ pub struct Manifest {
     pub fullscreen: bool,
     pub debuggable: bool,
     pub split: Option<String>,
+    pub application_metadatas: Vec<ApplicationMetadata>,
 }
 
 impl Manifest {
@@ -45,6 +46,11 @@ impl Manifest {
 
         let features: Vec<String> = self.features.iter().map(|f| f.to_string()).collect();
         let permissions: Vec<String> = self.permissions.iter().map(|p| p.to_string()).collect();
+        let application_metadatas: Vec<String> = self
+            .application_metadatas
+            .iter()
+            .map(|f| f.to_string())
+            .collect();
 
         format!(
             r#"<?xml version="1.0" encoding="utf-8"?>
@@ -65,6 +71,7 @@ impl Manifest {
             android:debuggable="{debuggable}"
             {icon}
             {fullscreen}>
+            {application_metadatas}
         <activity
                 android:name="android.app.NativeActivity"
                 android:label="{package_label}"
@@ -88,6 +95,7 @@ impl Manifest {
             target_name = &self.target_name,
             icon = icon,
             fullscreen = fullscreen,
+            application_metadatas = application_metadatas.join("\n"),
             debuggable = self.debuggable,
             features = features.join("\n"),
             permissions = permissions.join("\n"),
@@ -112,6 +120,21 @@ impl Feature {
         format!(
             r#"<uses-feature android:name="{}" android:required="{}"/>"#,
             &self.name, self.required,
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct ApplicationMetadata {
+    pub name: String,
+    pub value: String,
+}
+
+impl ApplicationMetadata {
+    pub fn to_string(&self) -> String {
+        format!(
+            r#"<meta-data android:name="{}" android:value="{}"/>"#,
+            self.name, self.value
         )
     }
 }


### PR DESCRIPTION
use case: `<meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>`

naming of application_metadatas is rather unfortunate, suggestions?