### PR TITLE
Add bitmap and hardware buffer

### DIFF
--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/rust-windowing/android-ndk-rs"
 [features]
 rustdoc = []
 test = []
+bitmap = []
 media = []
 
 [package.metadata.docs.rs]

--- a/ndk-sys/src/lib.rs
+++ b/ndk-sys/src/lib.rs
@@ -42,3 +42,7 @@ extern "C" {}
 #[cfg(all(feature = "media", target_os = "android"))]
 #[link(name = "mediandk")]
 extern "C" {}
+
+#[cfg(all(feature = "bitmap", target_os = "android"))]
+#[link(name = "jnigraphics")]
+extern "C" {}

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -13,10 +13,13 @@ repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [features]
 rustdoc = ["ffi/rustdoc", "jni", "jni-glue", "media", "hardware_buffer"]
+bitmap = ["ffi/bitmap"]
 media = ["ffi/media"]
 hardware_buffer = ["api-level-26"]
 api-level-24 = []
 api-level-26 = ["api-level-24"]
+api-level-29 = ["api-level-26"]
+api-level-30 = ["api-level-29"]
 
 [package.metadata.docs.rs]
 features = ["rustdoc"]

--- a/ndk/src/bitmap.rs
+++ b/ndk/src/bitmap.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "bitmap")]
+
+use jni_sys::{jobject, JNIEnv};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use std::{convert::TryInto, mem::MaybeUninit, ptr::NonNull};
+
+#[cfg(feature = "hardware_buffer")]
+use crate::hardware_buffer::HardwareBuffer;
+
+#[repr(i32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum BitmapError {
+    Unknown,
+    AllocationFailed = ffi::ANDROID_BITMAP_RESULT_ALLOCATION_FAILED,
+    BadParameter = ffi::ANDROID_BITMAP_RESULT_BAD_PARAMETER,
+    JniException = ffi::ANDROID_BITMAP_RESULT_JNI_EXCEPTION,
+}
+
+pub type BitmapResult<T, E = BitmapError> = std::result::Result<T, E>;
+
+impl BitmapError {
+    pub(crate) fn from_status<T>(
+        status: ffi::media_status_t,
+        on_success: impl FnOnce() -> T,
+    ) -> BitmapResult<T> {
+        Err(match status {
+            ffi::ANDROID_BITMAP_RESULT_SUCCESS => return Ok(on_success()),
+            ffi::ANDROID_BITMAP_RESULT_ALLOCATION_FAILED => BitmapError::AllocationFailed,
+            ffi::ANDROID_BITMAP_RESULT_BAD_PARAMETER => BitmapError::BadParameter,
+            ffi::ANDROID_BITMAP_RESULT_JNI_EXCEPTION => BitmapError::JniException,
+            _ => BitmapError::Unknown,
+        })
+    }
+}
+
+fn construct<T>(with_ptr: impl FnOnce(*mut T) -> i32) -> BitmapResult<T> {
+    let mut result = MaybeUninit::uninit();
+    let status = with_ptr(result.as_mut_ptr());
+    BitmapError::from_status(status, || unsafe { result.assume_init() })
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
+#[allow(non_camel_case_types)]
+pub enum BitmapFormat {
+    NONE = ffi::AndroidBitmapFormat_ANDROID_BITMAP_FORMAT_NONE,
+    RGBA_8888 = ffi::AndroidBitmapFormat_ANDROID_BITMAP_FORMAT_RGBA_8888,
+    RGB_565 = ffi::AndroidBitmapFormat_ANDROID_BITMAP_FORMAT_RGB_565,
+    #[deprecated = "Deprecated in API level 13. Because of the poor quality of this configuration, it is advised to use ARGB_8888 instead."]
+    RGBA_4444 = ffi::AndroidBitmapFormat_ANDROID_BITMAP_FORMAT_RGBA_4444,
+    A_8 = ffi::AndroidBitmapFormat_ANDROID_BITMAP_FORMAT_A_8,
+    RGBA_F16 = ffi::AndroidBitmapFormat_ANDROID_BITMAP_FORMAT_RGBA_F16,
+}
+
+#[derive(Debug)]
+pub struct AndroidBitmap {
+    env: ffi::JNIEnv,
+    inner: ffi::jobject,
+}
+
+impl AndroidBitmap {
+    /// Create an `AndroidBitmap` from JNI pointers
+    ///
+    /// # Safety
+    /// By calling this function, you assert that it these are valid pointers to JNI objects.
+    pub unsafe fn from_jni(env: JNIEnv, bitmap: jobject) -> Self {
+        Self {
+            env: env as _,
+            inner: bitmap as _,
+        }
+    }
+
+    pub fn get_info(&self) -> BitmapResult<AndroidBitmapInfo> {
+        let mut env = self.env;
+        let inner =
+            construct(|res| unsafe { ffi::AndroidBitmap_getInfo(&mut env, self.inner, res) })?;
+
+        Ok(AndroidBitmapInfo { inner })
+    }
+
+    pub fn lock_pixels(&self) -> BitmapResult<*mut std::os::raw::c_void> {
+        let mut env = self.env;
+        construct(|res| unsafe { ffi::AndroidBitmap_lockPixels(&mut env, self.inner, res) })
+    }
+
+    pub fn unlock_pixels(&self) -> BitmapResult<()> {
+        let mut env = self.env;
+        let status = unsafe { ffi::AndroidBitmap_unlockPixels(&mut env, self.inner) };
+        BitmapError::from_status(status, || ())
+    }
+
+    #[cfg(all(feature = "hardware_buffer", feature = "api-level-30"))]
+    pub fn get_hardware_buffer(&self) -> BitmapResult<HardwareBuffer> {
+        let mut env = self.env;
+        unsafe {
+            let result =
+                construct(|res| ffi::AndroidBitmap_getHardwareBuffer(&mut env, self.inner, res))?;
+            let non_null = if cfg!(debug_assertions) {
+                NonNull::new(result).expect("result should never be null")
+            } else {
+                NonNull::new_unchecked(result)
+            };
+            Ok(HardwareBuffer::from_ptr(non_null))
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct AndroidBitmapInfo {
+    inner: ffi::AndroidBitmapInfo,
+}
+
+// TODO: flesh out when API 30 is released
+#[cfg(feature = "api-level-30")]
+pub type AndroidBitmapInfoFlags = u32;
+
+impl AndroidBitmapInfo {
+    pub fn width(&self) -> u32 {
+        self.inner.width
+    }
+
+    pub fn height(&self) -> u32 {
+        self.inner.height
+    }
+
+    pub fn stride(&self) -> u32 {
+        self.inner.stride
+    }
+
+    pub fn format(&self) -> BitmapFormat {
+        let format = self.inner.format as u32;
+        format.try_into().unwrap()
+    }
+
+    #[cfg(feature = "api-level-30")]
+    pub fn flags(&self) -> AndroidBitmapInfoFlags {
+        self.inner.flags
+    }
+}

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -1,6 +1,12 @@
 #![cfg(feature = "hardware_buffer")]
-use std::ptr::NonNull;
+use jni_sys::{jobject, JNIEnv};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use std::{
+    convert::TryInto, mem::MaybeUninit, ops::Deref, os::raw::c_void, os::unix::io::RawFd,
+    ptr::NonNull,
+};
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct HardwareBufferUsage(pub ffi::AHardwareBuffer_UsageFlags);
 
 impl HardwareBufferUsage {
@@ -73,12 +79,317 @@ impl HardwareBufferUsage {
         Self(ffi::AHardwareBuffer_UsageFlags_AHARDWAREBUFFER_USAGE_VENDOR_19);
 }
 
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
+#[allow(non_camel_case_types)]
+pub enum HardwareBufferFormat {
+    R8G8B8A8_UNORM = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM,
+    R8G8B8X8_UNORM = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM,
+    R8G8B8_UNORM = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM,
+    R5G6B5_UNORM = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM,
+    R16G16B16A16_FLOAT = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT,
+    R10G10B10A2_UNORM = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM,
+    BLOB = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_BLOB,
+    D16_UNORM = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_D16_UNORM,
+    D24_UNORM = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_D24_UNORM,
+    D24_UNORM_S8_UINT = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_D24_UNORM_S8_UINT,
+    D32_FLOAT = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_D32_FLOAT,
+    D32_FLOAT_S8_UINT = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_D32_FLOAT_S8_UINT,
+    S8_UINT = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_S8_UINT,
+    Y8Cb8Cr8_420 = ffi::AHardwareBuffer_Format_AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420,
+}
+
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub struct HardwareBufferError(pub i32);
+
+pub type Result<T, E = HardwareBufferError> = std::result::Result<T, E>;
+
+pub type Rect = ffi::ARect;
+
+fn construct<T>(with_ptr: impl FnOnce(*mut T) -> i32) -> Result<T, HardwareBufferError> {
+    let mut result = MaybeUninit::uninit();
+    let status = with_ptr(result.as_mut_ptr());
+    if status == 0 {
+        Ok(unsafe { result.assume_init() })
+    } else {
+        Err(HardwareBufferError(status))
+    }
+}
+
+#[derive(Debug)]
 pub struct HardwareBuffer {
     inner: NonNull<ffi::AHardwareBuffer>,
 }
 
 impl HardwareBuffer {
+    /// Create a `HardwareBuffer` from a native pointer
+    ///
+    /// # Safety
+    /// By calling this function, you assert that it is a valid pointer to
+    /// an NDK `AHardwareBuffer`.
     pub unsafe fn from_ptr(ptr: NonNull<ffi::AHardwareBuffer>) -> Self {
         Self { inner: ptr }
+    }
+
+    fn as_ptr(&self) -> *mut ffi::AHardwareBuffer {
+        self.inner.as_ptr()
+    }
+
+    pub fn allocate(desc: HardwareBufferDesc) -> Result<HardwareBufferRef> {
+        unsafe {
+            let ptr = construct(|res| ffi::AHardwareBuffer_allocate(&desc.into_native(), res))?;
+
+            Ok(HardwareBufferRef {
+                inner: Self::from_ptr(NonNull::new_unchecked(ptr)),
+            })
+        }
+    }
+
+    /// Create a `HardwareBuffer` from JNI pointers
+    ///
+    /// # Safety
+    /// By calling this function, you assert that it these are valid pointers to JNI objects.
+    pub unsafe fn from_jni(env: JNIEnv, hardware_buffer: jobject) -> Self {
+        let ptr = ffi::AHardwareBuffer_fromHardwareBuffer(
+            &mut (env as ffi::JNIEnv),
+            hardware_buffer as _,
+        );
+
+        Self::from_ptr(NonNull::new_unchecked(ptr))
+    }
+
+    pub fn to_jni(&self, env: JNIEnv) -> jobject {
+        let ptr = unsafe {
+            ffi::AHardwareBuffer_toHardwareBuffer(&mut (env as ffi::JNIEnv), self.as_ptr())
+        };
+
+        ptr as jobject
+    }
+
+    pub fn describe(&self) -> HardwareBufferDesc {
+        let desc = unsafe {
+            let mut result = MaybeUninit::uninit();
+            ffi::AHardwareBuffer_describe(self.as_ptr(), result.as_mut_ptr());
+            result.assume_init()
+        };
+
+        HardwareBufferDesc {
+            width: desc.width,
+            height: desc.height,
+            layers: desc.layers,
+            format: desc.format.try_into().unwrap(),
+            usage: HardwareBufferUsage(desc.usage),
+            stride: desc.stride,
+        }
+    }
+
+    #[cfg(feature = "api-level-29")]
+    pub fn is_supported(desc: HardwareBufferDesc) -> bool {
+        let res = unsafe { ffi::AHardwareBuffer_isSupported(&desc.into_native()) };
+        res == 1
+    }
+
+    pub fn lock(
+        &self,
+        usage: HardwareBufferUsage,
+        fence: Option<RawFd>,
+        rect: Option<Rect>,
+    ) -> Result<*mut c_void> {
+        let fence = fence.unwrap_or(-1);
+        let rect = match rect {
+            Some(rect) => &rect,
+            None => std::ptr::null(),
+        };
+        construct(|res| unsafe {
+            ffi::AHardwareBuffer_lock(self.as_ptr(), usage.0, fence, rect, res)
+        })
+    }
+
+    #[cfg(feature = "api-level-29")]
+    pub fn lock_and_get_info(
+        &self,
+        usage: HardwareBufferUsage,
+        fence: Option<RawFd>,
+        rect: Option<Rect>,
+    ) -> Result<LockedPlaneInfo> {
+        let fence = fence.unwrap_or(-1);
+        let rect = match rect {
+            Some(rect) => &rect,
+            None => std::ptr::null(),
+        };
+        let mut virtual_address = MaybeUninit::uninit();
+        let mut bytes_per_pixel = MaybeUninit::uninit();
+        let mut bytes_per_stride = MaybeUninit::uninit();
+        let status = unsafe {
+            ffi::AHardwareBuffer_lockAndGetInfo(
+                self.as_ptr(),
+                usage.0,
+                fence,
+                rect,
+                virtual_address.as_mut_ptr(),
+                bytes_per_pixel.as_mut_ptr(),
+                bytes_per_stride.as_mut_ptr(),
+            )
+        };
+        if status == 0 {
+            Ok(unsafe {
+                LockedPlaneInfo {
+                    virtual_address: virtual_address.assume_init(),
+                    bytes_per_pixel: bytes_per_pixel.assume_init() as u32,
+                    bytes_per_stride: bytes_per_stride.assume_init() as u32,
+                }
+            })
+        } else {
+            Err(HardwareBufferError(status))
+        }
+    }
+
+    #[cfg(feature = "api-level-29")]
+    pub fn lock_planes(
+        &self,
+        usage: HardwareBufferUsage,
+        fence: Option<RawFd>,
+        rect: Option<Rect>,
+    ) -> Result<HardwareBufferPlanes> {
+        let fence = fence.unwrap_or(-1);
+        let rect = match rect {
+            Some(rect) => &rect,
+            None => std::ptr::null(),
+        };
+        let planes = construct(|res| unsafe {
+            ffi::AHardwareBuffer_lockPlanes(self.as_ptr(), usage.0, fence, rect, res)
+        })?;
+
+        Ok(HardwareBufferPlanes {
+            inner: planes,
+            index: 0,
+        })
+    }
+
+    pub fn unlock(&self) -> Result<()> {
+        let status = unsafe { ffi::AHardwareBuffer_unlock(self.as_ptr(), std::ptr::null_mut()) };
+        if status == 0 {
+            Ok(())
+        } else {
+            Err(HardwareBufferError(status))
+        }
+    }
+
+    /// Returns a fence file descriptor that will become signalled when unlocking is completed,
+    /// or `None` if unlocking is already finished.
+    pub fn unlock_async(&self) -> Result<Option<RawFd>> {
+        let fence = construct(|res| unsafe { ffi::AHardwareBuffer_unlock(self.as_ptr(), res) })?;
+        Ok(match fence {
+            -1 => None,
+            fence => Some(fence),
+        })
+    }
+
+    pub fn recv_handle_from_unix_socket(socket_fd: RawFd) -> Result<Self> {
+        unsafe {
+            let ptr =
+                construct(|res| ffi::AHardwareBuffer_recvHandleFromUnixSocket(socket_fd, res))?;
+
+            Ok(Self::from_ptr(NonNull::new_unchecked(ptr)))
+        }
+    }
+
+    pub fn send_handle_to_unix_socket(&self, socket_fd: RawFd) -> Result<()> {
+        unsafe {
+            let status = ffi::AHardwareBuffer_sendHandleToUnixSocket(self.as_ptr(), socket_fd);
+            if status == 0 {
+                Ok(())
+            } else {
+                Err(HardwareBufferError(status))
+            }
+        }
+    }
+
+    pub fn acquire(&self) -> HardwareBufferRef {
+        unsafe {
+            ffi::AHardwareBuffer_acquire(self.as_ptr());
+        }
+        HardwareBufferRef {
+            inner: HardwareBuffer { inner: self.inner },
+        }
+    }
+}
+
+/// A `HardwareBuffer` with an owned reference, the reference is released when dropped.
+/// It behaves much like a strong `Rc` reference.
+#[derive(Debug)]
+pub struct HardwareBufferRef {
+    inner: HardwareBuffer,
+}
+
+impl Deref for HardwareBufferRef {
+    type Target = HardwareBuffer;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl Drop for HardwareBufferRef {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::AHardwareBuffer_release(self.inner.as_ptr());
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct HardwareBufferDesc {
+    width: u32,
+    height: u32,
+    layers: u32,
+    format: HardwareBufferFormat,
+    usage: HardwareBufferUsage,
+    stride: u32,
+}
+
+impl HardwareBufferDesc {
+    fn into_native(self) -> ffi::AHardwareBuffer_Desc {
+        ffi::AHardwareBuffer_Desc {
+            width: self.width,
+            height: self.height,
+            layers: self.layers,
+            format: self.format.try_into().unwrap(),
+            usage: self.usage.0,
+            stride: self.stride,
+            rfu0: 0,
+            rfu1: 0,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct LockedPlaneInfo {
+    pub virtual_address: *mut c_void,
+    pub bytes_per_pixel: u32,
+    pub bytes_per_stride: u32,
+}
+
+#[derive(Debug)]
+pub struct HardwareBufferPlanes {
+    inner: ffi::AHardwareBuffer_Planes,
+    index: u32,
+}
+
+impl Iterator for HardwareBufferPlanes {
+    type Item = LockedPlaneInfo;
+
+    fn next(&mut self) -> Option<LockedPlaneInfo> {
+        if self.index == self.inner.planeCount {
+            None
+        } else {
+            let plane = self.inner.planes[self.index as usize];
+            self.index += 1;
+            Some(LockedPlaneInfo {
+                virtual_address: plane.data,
+                bytes_per_pixel: plane.pixelStride,
+                bytes_per_stride: plane.rowStride,
+            })
+        }
     }
 }

--- a/ndk/src/lib.rs
+++ b/ndk/src/lib.rs
@@ -16,6 +16,7 @@
 #![warn(missing_debug_implementations)]
 
 pub mod asset;
+pub mod bitmap;
 pub mod configuration;
 pub mod event;
 pub mod input_queue;


### PR DESCRIPTION
Continues the work for #22 

* adds Android Bitmap module. There are some additions to the NDK Bitmap in API-level-30, but I don't think it makes sense to add all of it before the full release, as things might still change.
* adds HardwareBuffer implementation. I'm not sure all the fence stuff is right, as I have no idea how to test it yet. I'll dive deeper when adding the camera API, that would also be the perfect time to add an example app using all of these modules.