### PR TITLE
[ndk-build] Fix paths to toolchain and clang on Windows

### DIFF
--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -193,7 +193,7 @@ impl Ndk {
 
     pub fn toolchain_bin(&self, bin: &str, target: Target) -> Result<PathBuf, NdkError> {
         #[cfg(target_os = "windows")]
-        let ext = ".cmd";
+        let ext = ".exe";
         #[cfg(not(target_os = "windows"))]
         let ext = "";
 

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -176,14 +176,15 @@ impl Ndk {
         #[cfg(not(target_os = "windows"))]
         let ext = "";
 
-        let bin_name = format!("{}{}-clang{}", target.ndk_llvm_triple(), platform, ext);
+        let bin_name = format!("{}{}-clang", target.ndk_llvm_triple(), platform);
+        let bin_path = self.toolchain_dir()?.join("bin");
 
-        let clang = self.toolchain_dir()?.join("bin").join(&bin_name);
+        let clang = bin_path.join(format!("{}{}", &bin_name, ext));
         if !clang.exists() {
             return Err(NdkError::PathNotFound(clang));
         }
 
-        let clang_pp = clang.with_file_name(format!("{}++", &bin_name));
+        let clang_pp = bin_path.join(format!("{}++{}", &bin_name, ext));
         if !clang_pp.exists() {
             return Err(NdkError::PathNotFound(clang_pp));
         }


### PR DESCRIPTION
Fix for https://github.com/rust-windowing/android-ndk-rs/issues/29

Toolchain binaries in the NDK are not wrapped by scripts and are thus normal executables with `.exe` extension. Only clang has (bash and batch) wrapper scripts, with none and with `.cmd` extension respectively.

I accidentally appended `++` after the filename in https://github.com/rust-windowing/android-ndk-rs/commit/33c00289ecc0a8ba54824c5c71b6a63233163c15 which should have gone inbetween the executable name and the (optional) extension. With this fix the path is properly `...-clang.cmd` and `...-clang++.cmd`