### PR TITLE
[cargo-apk/ndk-build] Use dunce to get rid of UNC paths on Windows

### DIFF
--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
 cargo-subcommand = "0.4.4"
+dunce = "1.0"
 env_logger = "0.7.1"
 exitfailure = "0.5.1"
 log = "0.4.8"

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -31,7 +31,9 @@ impl<'a> ApkBuilder<'a> {
                 vec![ndk.detect_abi().unwrap_or(Target::Arm64V8a)]
             }
         };
-        let build_dir = cmd.target_dir().join(cmd.profile()).join("apk");
+        let build_dir = dunce::canonicalize(cmd.target_dir())?
+            .join(cmd.profile())
+            .join("apk");
         Ok(Self {
             cmd,
             ndk,
@@ -64,9 +66,7 @@ impl<'a> ApkBuilder<'a> {
 
         for target in &self.build_targets {
             let triple = target.rust_triple();
-            let build_dir = self
-                .cmd
-                .target_dir()
+            let build_dir = dunce::canonicalize(self.cmd.target_dir())?
                 .join(target.rust_triple())
                 .join(self.cmd.profile());
             let artifact = build_dir

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -12,5 +12,6 @@ repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
 dirs = "2.0.2"
+dunce = "1.0"
 serde = { version = "1.0.104", features = ["derive"] }
 which = "3.1.0"

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -101,7 +101,7 @@ impl Ndk {
         if !path.exists() {
             return Err(NdkError::CmdNotFound(tool.to_string()));
         }
-        Ok(Command::new(std::fs::canonicalize(path)?))
+        Ok(Command::new(dunce::canonicalize(path)?))
     }
 
     pub fn platform_tool(&self, tool: &str) -> Result<Command, NdkError> {
@@ -109,7 +109,7 @@ impl Ndk {
         if !path.exists() {
             return Err(NdkError::CmdNotFound(tool.to_string()));
         }
-        Ok(Command::new(std::fs::canonicalize(path)?))
+        Ok(Command::new(dunce::canonicalize(path)?))
     }
 
     pub fn default_platform(&self) -> u32 {

--- a/ndk-build/src/readelf.rs
+++ b/ndk-build/src/readelf.rs
@@ -105,7 +105,7 @@ fn find_library_path<S: AsRef<Path>>(
     for path in paths {
         let lib_path = path.join(&library);
         if lib_path.exists() {
-            return Ok(Some(std::fs::canonicalize(lib_path)?));
+            return Ok(Some(dunce::canonicalize(lib_path)?));
         }
     }
     Ok(None)


### PR DESCRIPTION
Fix for https://github.com/rust-windowing/android-ndk-rs/issues/29

`SubCommand::target_dir()` seems to return an `std::fs::canonicalize`d path which is also called explicitly in `ndk-build`: this function utilizes [a Win32 function](https://doc.rust-lang.org/std/fs/fn.canonicalize.html#platform-specific-behavior) that returns UNC canonicalized paths with a special prefix that is not understood by many tools, including `cmd.exe`. 

Luckily the `dunce` crate has already solved all this trouble for us, and utilizes `std::fs::canonicalize` on platforms where this problem doesn't exist.