### PR TITLE
fixup: cargo-apk: Do not canonicalize target_dir(), only strip UNC

### DIFF
--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -31,7 +31,7 @@ impl<'a> ApkBuilder<'a> {
                 vec![ndk.detect_abi().unwrap_or(Target::Arm64V8a)]
             }
         };
-        let build_dir = dunce::canonicalize(cmd.target_dir())?
+        let build_dir = dunce::simplified(cmd.target_dir())
             .join(cmd.profile())
             .join("apk");
         Ok(Self {
@@ -66,7 +66,7 @@ impl<'a> ApkBuilder<'a> {
 
         for target in &self.build_targets {
             let triple = target.rust_triple();
-            let build_dir = dunce::canonicalize(self.cmd.target_dir())?
+            let build_dir = dunce::simplified(self.cmd.target_dir())
                 .join(target.rust_triple())
                 .join(self.cmd.profile());
             let artifact = build_dir


### PR DESCRIPTION
My previous commit introduced a canonicalize() here because target_dir()
returns a UNC path that is not supported by most tools. Needing the ?
operator should have rang a bell: dunce::canonicalize() calls
fs::canonicalize() first before stripping the UNC path. It bails if the
path doesn't exist, which happens in a clean environment when ./target
doesn't exist yet.

Luckily dunce also has a simplified() function to strip the UNC part off
the path without canonicalizing first.

Fixes: e9a6ee1c7321335e5cbb6eb4e5e9045531fe43e2

---

Apologies for the breakage!

