### PR TITLE
Added `ndk_glue::main` attribute macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "ndk",
+    "ndk-macro",
     "ndk-build",
     "ndk-examples",
     "ndk-glue",

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 crate-type = ["lib", "cdylib"]
 ```
 
+Wraps `main` function using attribute macro `ndk::glue::main`:
+
 `src/lib.rs`
 ```rust
-#[cfg(target_os = "android")]
-ndk_glue::ndk_glue!(main);
-
+#[cfg_attr(target_os = "android", ndk_glue::main(backtrace))]
 pub fn main() {
     println!("hello world");
 }
@@ -38,6 +38,17 @@ cargo apk run
 ## Logging and stdout
 Stdout is redirected to the android log api when using `ndk-glue`. Any logger that logs to
 stdout should therefore work.
+
+### Android logger
+Android logger can be setup using feature "logger" and attribute macro like so:
+
+`src/lib.rs`
+```rust
+#[cfg_attr(target_os = "android", ndk_glue::main(logger(debug, "my-tag")))]
+pub fn main() {
+    println!("hello world");
+}
+```
 
 ## JNI
 TODO: talk more about jni and add some examples

--- a/ndk-examples/examples/hello_world.rs
+++ b/ndk-examples/examples/hello_world.rs
@@ -1,6 +1,4 @@
-#[cfg(target_os = "android")]
-ndk_glue::ndk_glue!(main);
-
+#[cfg_attr(target_os = "android", ndk_glue::main(backtrace))]
 fn main() {
     println!("hello world");
 }

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -10,6 +10,12 @@ license = "MIT OR Apache-2.0"
 android_log-sys = "0.1.2"
 ndk = { path = "../ndk", version = "0.1" }
 ndk-sys = { path = "../ndk-sys", version = "0.1" }
+ndk-macro = { path = "../ndk-macro", version = "0.1" }
 lazy_static = "1.4.0"
 libc = "0.2.66"
 log = "0.4.8"
+android_logger = { version = "0.8.6", optional = true }
+
+[features]
+default = []
+logger = ["android_logger", "ndk-macro/logger"]

--- a/ndk-glue/src/lib.rs
+++ b/ndk-glue/src/lib.rs
@@ -14,25 +14,7 @@ use std::ptr::NonNull;
 use std::sync::{RwLock, RwLockReadGuard};
 use std::thread;
 
-#[macro_export]
-macro_rules! ndk_glue {
-    ($main:ident) => {
-        #[no_mangle]
-        unsafe extern "C" fn ANativeActivity_onCreate(
-            activity: *mut std::os::raw::c_void,
-            saved_state: *mut std::os::raw::c_void,
-            saved_state_size: usize,
-        ) {
-            std::env::set_var("RUST_BACKTRACE", "1");
-            $crate::init(
-                activity as _,
-                saved_state as _,
-                saved_state_size as _,
-                $main,
-            );
-        }
-    };
-}
+pub use ndk_macro::main;
 
 pub fn android_log(level: Level, tag: &CStr, msg: &CStr) {
     use android_log_sys::LogPriority;

--- a/ndk-macro/Cargo.toml
+++ b/ndk-macro/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ndk-macro"
+version = "0.1.0"
+authors = ["K. <kayo@illumium.org>"]
+edition = "2018"
+description = "Helper macros for android ndk"
+license = "MIT OR Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+log = "0.4.8"
+proc-macro2 = "1.0.18"
+proc-macro-crate = "0.1.4"
+quote = "1.0.6"
+syn = { version = "1.0.30", features = ["full"] }
+
+[features]
+default = []
+logger = []

--- a/ndk-macro/src/expand.rs
+++ b/ndk-macro/src/expand.rs
@@ -1,0 +1,256 @@
+mod backtrace;
+
+#[cfg(feature = "logger")]
+mod logger;
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::ItemFn;
+
+use crate::{crate_name, parse::MainAttr};
+
+impl MainAttr {
+    pub fn expand(&self, main_fn_item: &ItemFn) -> TokenStream {
+        let main_fn_name = &main_fn_item.sig.ident;
+        let glue_crate = format_ident!(
+            "{}",
+            crate_name("ndk-glue").expect("No 'ndk-glue' crate found!")
+        );
+
+        let preamble = vec![
+            self.expand_backtrace(),
+            #[cfg(feature = "logger")]
+            self.expand_logger(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+
+        quote! {
+            #[no_mangle]
+            unsafe extern "C" fn ANativeActivity_onCreate(
+                activity: *mut std::os::raw::c_void,
+                saved_state: *mut std::os::raw::c_void,
+                saved_state_size: usize,
+            ) {
+                #(#preamble)*
+                #glue_crate::init(
+                    activity as _,
+                    saved_state as _,
+                    saved_state_size as _,
+                    #main_fn_name,
+                );
+            }
+
+            #main_fn_item
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use proc_macro2::TokenStream;
+    use quote::quote;
+    use syn::{parse_quote, ItemFn};
+
+    use super::MainAttr;
+
+    fn main(attr: &MainAttr, item: &ItemFn) -> TokenStream {
+        attr.expand(item)
+    }
+
+    #[test]
+    fn main_without_props() {
+        let attr = parse_quote! {};
+        let item = parse_quote! { fn main() {} };
+        let actual = main(&attr, &item);
+        let expected = quote! {
+            #[no_mangle]
+            unsafe extern "C" fn ANativeActivity_onCreate(
+                activity: *mut std::os::raw::c_void,
+                saved_state: *mut std::os::raw::c_void,
+                saved_state_size: usize,
+            ) {
+                ndk_glue::init(
+                    activity as _,
+                    saved_state as _,
+                    saved_state_size as _,
+                    main,
+                );
+            }
+            fn main() {}
+        };
+        assert_eq!(actual.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn main_with_backtrace_prop() {
+        let attr = parse_quote! { backtrace };
+        let item = parse_quote! { fn main() {} };
+        let actual = main(&attr, &item);
+        let expected = quote! {
+            #[no_mangle]
+            unsafe extern "C" fn ANativeActivity_onCreate(
+                activity: *mut std::os::raw::c_void,
+                saved_state: *mut std::os::raw::c_void,
+                saved_state_size: usize,
+            ) {
+                std::env::set_var("RUST_BACKTRACE", "1");
+                ndk_glue::init(
+                    activity as _,
+                    saved_state as _,
+                    saved_state_size as _,
+                    main,
+                );
+            }
+            fn main() {}
+        };
+        assert_eq!(actual.to_string(), expected.to_string());
+    }
+
+    #[cfg(feature = "logger")]
+    mod logger {
+        use super::*;
+
+        #[test]
+        fn main_with_logger_prop_empty() {
+            let attr = parse_quote! { logger };
+            let item = parse_quote! { fn main() {} };
+            let actual = main(&attr, &item);
+            let expected = quote! {
+                #[no_mangle]
+                unsafe extern "C" fn ANativeActivity_onCreate(
+                    activity: *mut std::os::raw::c_void,
+                    saved_state: *mut std::os::raw::c_void,
+                    saved_state_size: usize,
+                ) {
+                    android_logger::init_once(
+                        android_logger::Config::default()
+                    );
+                    ndk_glue::init(
+                        activity as _,
+                        saved_state as _,
+                        saved_state_size as _,
+                        main,
+                    );
+                }
+                fn main() {}
+            };
+            assert_eq!(actual.to_string(), expected.to_string());
+        }
+
+        #[test]
+        fn main_with_logger_prop_with_min_level() {
+            let attr = parse_quote! { logger(debug) };
+            let item = parse_quote! { fn main() {} };
+            let actual = main(&attr, &item);
+            let expected = quote! {
+                #[no_mangle]
+                unsafe extern "C" fn ANativeActivity_onCreate(
+                    activity: *mut std::os::raw::c_void,
+                    saved_state: *mut std::os::raw::c_void,
+                    saved_state_size: usize,
+                ) {
+                    android_logger::init_once(
+                        android_logger::Config::default()
+                            .with_min_level(log::Level::Debug)
+                    );
+                    ndk_glue::init(
+                        activity as _,
+                        saved_state as _,
+                        saved_state_size as _,
+                        main,
+                    );
+                }
+                fn main() {}
+            };
+            assert_eq!(actual.to_string(), expected.to_string());
+        }
+
+        #[test]
+        fn main_with_logger_prop_with_tag() {
+            let attr = parse_quote! { logger("my-tag") };
+            let item = parse_quote! { fn my_main() {} };
+            let actual = main(&attr, &item);
+            let expected = quote! {
+                #[no_mangle]
+                unsafe extern "C" fn ANativeActivity_onCreate(
+                    activity: *mut std::os::raw::c_void,
+                    saved_state: *mut std::os::raw::c_void,
+                    saved_state_size: usize,
+                ) {
+                    android_logger::init_once(
+                        android_logger::Config::default()
+                            .with_tag("my-tag")
+                    );
+                    ndk_glue::init(
+                        activity as _,
+                        saved_state as _,
+                        saved_state_size as _,
+                        my_main,
+                    );
+                }
+                fn my_main() {}
+            };
+            assert_eq!(actual.to_string(), expected.to_string());
+        }
+
+        #[test]
+        fn main_with_logger_prop_with_min_level_and_with_tag() {
+            let attr = parse_quote! { logger(warn, "my-tag") };
+            let item = parse_quote! { fn my_main() {} };
+            let actual = main(&attr, &item);
+            let expected = quote! {
+                #[no_mangle]
+                unsafe extern "C" fn ANativeActivity_onCreate(
+                    activity: *mut std::os::raw::c_void,
+                    saved_state: *mut std::os::raw::c_void,
+                    saved_state_size: usize,
+                ) {
+                    android_logger::init_once(
+                        android_logger::Config::default()
+                            .with_tag("my-tag")
+                            .with_min_level(log::Level::Warn)
+                    );
+                    ndk_glue::init(
+                        activity as _,
+                        saved_state as _,
+                        saved_state_size as _,
+                        my_main,
+                    );
+                }
+                fn my_main() {}
+            };
+            assert_eq!(actual.to_string(), expected.to_string());
+        }
+
+        #[test]
+        fn main_with_backtrace_prop_and_logger_prop() {
+            let attr = parse_quote! { backtrace, logger("my-tag") };
+            let item = parse_quote! { fn main() {} };
+            let actual = main(&attr, &item);
+            let expected = quote! {
+                #[no_mangle]
+                unsafe extern "C" fn ANativeActivity_onCreate(
+                    activity: *mut std::os::raw::c_void,
+                    saved_state: *mut std::os::raw::c_void,
+                    saved_state_size: usize,
+                ) {
+                    std::env::set_var("RUST_BACKTRACE", "1");
+                    android_logger::init_once(
+                        android_logger::Config::default()
+                            .with_tag("my-tag")
+                    );
+                    ndk_glue::init(
+                        activity as _,
+                        saved_state as _,
+                        saved_state_size as _,
+                        main,
+                    );
+                }
+                fn main() {}
+            };
+            assert_eq!(actual.to_string(), expected.to_string());
+        }
+    }
+}

--- a/ndk-macro/src/expand/backtrace.rs
+++ b/ndk-macro/src/expand/backtrace.rs
@@ -1,0 +1,14 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::parse::MainAttr;
+
+impl MainAttr {
+    pub fn expand_backtrace(&self) -> Option<TokenStream> {
+        if self.backtrace_enabled() {
+            Some(quote! { std::env::set_var("RUST_BACKTRACE", "1"); })
+        } else {
+            None
+        }
+    }
+}

--- a/ndk-macro/src/expand/logger.rs
+++ b/ndk-macro/src/expand/logger.rs
@@ -1,0 +1,47 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use crate::{crate_name, parse::MainAttr};
+
+impl MainAttr {
+    pub fn expand_logger(&self) -> Option<TokenStream> {
+        self.logger_config().map(|config| {
+            let android_logger_crate = format_ident!(
+                "{}",
+                crate_name("android_logger").expect("No 'android_logger' crate found!")
+            );
+            let mut with_key = Vec::new();
+            let mut with_value = Vec::new();
+
+            if let Some(tag) = &config.tag {
+                with_key.push(quote! { with_tag });
+                with_value.push(quote! { #tag });
+            }
+            if let Some(level) = &config.level {
+                let log_crate =
+                    format_ident!("{}", crate_name("log").expect("No 'log' crate found!"));
+                let level = level_to_token(level);
+
+                with_key.push(quote! { with_min_level });
+                with_value.push(quote! { #log_crate::Level::#level });
+            }
+
+            quote! {
+                #android_logger_crate::init_once(
+                    #android_logger_crate::Config::default()
+                    #(. #with_key ( #with_value ) )*
+                );
+            }
+        })
+    }
+}
+
+fn level_to_token(level: &log::Level) -> TokenStream {
+    match level {
+        log::Level::Error => quote! { Error },
+        log::Level::Warn => quote! { Warn },
+        log::Level::Info => quote! { Info },
+        log::Level::Debug => quote! { Debug },
+        log::Level::Trace => quote! { Trace },
+    }
+}

--- a/ndk-macro/src/lib.rs
+++ b/ndk-macro/src/lib.rs
@@ -1,0 +1,23 @@
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, ItemFn};
+
+mod expand;
+mod parse;
+
+use parse::MainAttr;
+
+#[cfg(not(test))]
+pub(crate) use proc_macro_crate::crate_name;
+
+#[cfg(test)]
+pub(crate) fn crate_name(name: &str) -> Result<String, String> {
+    Ok(name.replace('-', "_"))
+}
+
+#[proc_macro_attribute]
+pub fn main(attr_input: TokenStream, item_input: TokenStream) -> TokenStream {
+    let item_ast = parse_macro_input!(item_input as ItemFn);
+    let attr_ast = parse_macro_input!(attr_input as MainAttr);
+
+    attr_ast.expand(&item_ast).into()
+}

--- a/ndk-macro/src/parse.rs
+++ b/ndk-macro/src/parse.rs
@@ -1,0 +1,175 @@
+mod backtrace;
+
+#[cfg(feature = "logger")]
+mod logger;
+
+use syn::{
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    Result, Token,
+};
+
+use backtrace::*;
+
+#[cfg(feature = "logger")]
+use logger::*;
+
+pub struct MainAttr {
+    props: Punctuated<MainProp, Token![,]>,
+}
+
+impl Parse for MainAttr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            props: Punctuated::parse_terminated(input)?,
+        })
+    }
+}
+
+pub enum MainProp {
+    Backtrace(MainPropBacktrace),
+
+    #[cfg(feature = "logger")]
+    Logger(MainPropLogger),
+}
+
+impl Parse for MainProp {
+    fn parse(input: ParseStream) -> Result<Self> {
+        #[cfg(feature = "logger")]
+        {
+            let lookahead = input.lookahead1();
+            if lookahead.peek(backtrace::keyword::backtrace) {
+                input.parse().map(MainProp::Backtrace)
+            } else if lookahead.peek(logger::keyword::logger) {
+                input.parse().map(MainProp::Logger)
+            } else {
+                Err(lookahead.error())
+            }
+        }
+
+        #[cfg(not(feature = "logger"))]
+        {
+            let lookahead = input.lookahead1();
+            if lookahead.peek(backtrace::keyword::backtrace) {
+                input.parse().map(MainProp::Backtrace)
+            } else {
+                Err(lookahead.error())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn empty_attr() {
+        let attr: MainAttr = parse_quote! {};
+
+        assert_eq!(attr.props.len(), 0);
+        assert!(!attr.backtrace_enabled());
+    }
+
+    #[should_panic]
+    #[test]
+    fn invalid_attr() {
+        let _attr: MainAttr = parse_quote! { wrong };
+    }
+
+    #[test]
+    fn single_backtrace_prop() {
+        let attr: MainAttr = parse_quote! { backtrace };
+
+        assert_eq!(attr.props.len(), 1);
+        assert!(attr.backtrace_enabled());
+    }
+
+    #[test]
+    fn repeated_backtrace_props() {
+        let attr: MainAttr = parse_quote! { backtrace, backtrace };
+
+        assert_eq!(attr.props.len(), 2);
+        assert!(attr.backtrace_enabled());
+    }
+
+    #[cfg(feature = "logger")]
+    mod logger {
+        use super::*;
+
+        #[test]
+        fn single_log_prop_with_level_prop() {
+            let attr: MainAttr = parse_quote! { logger(debug) };
+
+            assert_eq!(attr.props.len(), 1);
+
+            let config = attr.logger_config().unwrap();
+
+            assert_eq!(config.level, Some(log::Level::Debug));
+            assert_eq!(config.tag, None);
+        }
+
+        #[test]
+        fn single_log_prop_with_tag_prop() {
+            let attr: MainAttr = parse_quote! { logger("my-tag") };
+
+            assert_eq!(attr.props.len(), 1);
+
+            let config = attr.logger_config().unwrap();
+
+            assert_eq!(config.level, None);
+            assert_eq!(config.tag.unwrap(), "my-tag");
+        }
+
+        #[test]
+        fn single_log_prop_with_level_and_tag_prop() {
+            let attr: MainAttr = parse_quote! { logger(error, "my-app") };
+
+            assert_eq!(attr.props.len(), 1);
+
+            let config = attr.logger_config().unwrap();
+
+            assert_eq!(config.level, Some(log::Level::Error));
+            assert_eq!(config.tag.unwrap(), "my-app");
+        }
+
+        #[test]
+        fn single_log_prop_with_level_and_tag_prop_and_backtrace_prop() {
+            let attr: MainAttr = parse_quote! { logger(error, "my-app"), backtrace };
+
+            assert_eq!(attr.props.len(), 2);
+            assert!(attr.backtrace_enabled());
+
+            let config = attr.logger_config().unwrap();
+
+            assert_eq!(config.level, Some(log::Level::Error));
+            assert_eq!(config.tag.unwrap(), "my-app");
+        }
+
+        #[test]
+        fn multiple_log_props_with_level_and_tag_prop() {
+            let attr: MainAttr = parse_quote! { logger(error), logger("my-app") };
+
+            assert_eq!(attr.props.len(), 2);
+
+            let config = attr.logger_config().unwrap();
+
+            assert_eq!(config.level, Some(log::Level::Error));
+            assert_eq!(config.tag.unwrap(), "my-app");
+        }
+
+        #[test]
+        fn multiple_log_props_with_level_and_tag_prop_with_override() {
+            let attr: MainAttr =
+                parse_quote! { logger(error), logger("my-app"), logger(info, "some-other") };
+
+            assert_eq!(attr.props.len(), 3);
+
+            let config = attr.logger_config().unwrap();
+
+            assert_eq!(config.level, Some(log::Level::Info));
+            assert_eq!(config.tag.unwrap(), "some-other");
+        }
+    }
+}

--- a/ndk-macro/src/parse/backtrace.rs
+++ b/ndk-macro/src/parse/backtrace.rs
@@ -1,0 +1,44 @@
+use syn::{
+    parse::{Parse, ParseStream},
+    Result,
+};
+
+use super::MainAttr;
+
+pub mod keyword {
+    use syn::custom_keyword as kw;
+
+    kw!(backtrace);
+}
+
+impl MainAttr {
+    pub fn backtrace_enabled(&self) -> bool {
+        #[cfg(not(feature = "logger"))]
+        {
+            !self.props.is_empty()
+        }
+
+        #[cfg(feature = "logger")]
+        self.props.iter().any(|prop| {
+            use super::MainProp;
+            if let MainProp::Backtrace { .. } = prop {
+                true
+            } else {
+                false
+            }
+        })
+    }
+}
+
+pub struct MainPropBacktrace {
+    #[allow(unused)]
+    key: keyword::backtrace,
+}
+
+impl Parse for MainPropBacktrace {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            key: input.parse()?,
+        })
+    }
+}

--- a/ndk-macro/src/parse/logger.rs
+++ b/ndk-macro/src/parse/logger.rs
@@ -1,0 +1,145 @@
+use syn::{
+    parenthesized,
+    parse::{Lookahead1, Parse, ParseStream},
+    punctuated::Punctuated,
+    token::Paren,
+    LitStr, Result, Token,
+};
+
+use super::{MainAttr, MainProp};
+
+pub mod keyword {
+    use syn::custom_keyword as kw;
+
+    kw!(logger);
+    kw!(error);
+    kw!(warn);
+    kw!(info);
+    kw!(debug);
+    kw!(trace);
+}
+
+impl MainAttr {
+    pub fn logger_config(&self) -> Option<LoggerConfig> {
+        let mut config = None;
+        for prop in &self.props {
+            if let MainProp::Logger(MainPropLogger { ref props, .. }) = prop {
+                if config.is_none() {
+                    config = Some(LoggerConfig::default());
+                }
+                config.as_mut().unwrap().merge(props);
+            }
+        }
+        config
+    }
+}
+
+pub struct MainPropLogger {
+    #[allow(unused)]
+    key: keyword::logger,
+    #[allow(unused)]
+    paren: Option<Paren>,
+    props: Punctuated<LoggerProp, Token![,]>,
+}
+
+impl Parse for MainPropLogger {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let key = input.parse()?;
+        let (paren, props) = if input.peek(Paren) {
+            let content;
+            (
+                Some(parenthesized!(content in input)),
+                Punctuated::parse_terminated(&content)?,
+            )
+        } else {
+            (None, Punctuated::default())
+        };
+
+        Ok(Self { key, paren, props })
+    }
+}
+
+pub enum LoggerProp {
+    Level(LogLevel),
+    Tag(LitStr),
+}
+
+impl Parse for LoggerProp {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let lookahead = input.lookahead1();
+        if LogLevel::peek(&lookahead) {
+            Ok(LoggerProp::Level(input.parse()?))
+        } else if lookahead.peek(LitStr) {
+            Ok(LoggerProp::Tag(input.parse()?))
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+pub enum LogLevel {
+    Error(keyword::error),
+    Warn(keyword::warn),
+    Info(keyword::info),
+    Debug(keyword::debug),
+    Trace(keyword::trace),
+}
+
+impl<'a> Into<log::Level> for &'a LogLevel {
+    fn into(self) -> log::Level {
+        use log::Level::*;
+        match self {
+            LogLevel::Error(_) => Error,
+            LogLevel::Warn(_) => Warn,
+            LogLevel::Info(_) => Info,
+            LogLevel::Debug(_) => Debug,
+            LogLevel::Trace(_) => Trace,
+        }
+    }
+}
+
+impl LogLevel {
+    pub fn peek(lookahead: &Lookahead1) -> bool {
+        lookahead.peek(keyword::error)
+            || lookahead.peek(keyword::warn)
+            || lookahead.peek(keyword::info)
+            || lookahead.peek(keyword::debug)
+            || lookahead.peek(keyword::trace)
+    }
+}
+
+impl Parse for LogLevel {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(keyword::error) {
+            Ok(LogLevel::Error(input.parse()?))
+        } else if lookahead.peek(keyword::warn) {
+            Ok(LogLevel::Warn(input.parse()?))
+        } else if lookahead.peek(keyword::info) {
+            Ok(LogLevel::Info(input.parse()?))
+        } else if lookahead.peek(keyword::debug) {
+            Ok(LogLevel::Debug(input.parse()?))
+        } else if lookahead.peek(keyword::trace) {
+            Ok(LogLevel::Trace(input.parse()?))
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct LoggerConfig {
+    pub level: Option<log::Level>,
+    pub tag: Option<String>,
+}
+
+impl LoggerConfig {
+    pub fn merge(&mut self, props: &Punctuated<LoggerProp, Token![,]>) {
+        for prop in props {
+            match prop {
+                LoggerProp::Level(level) => self.level = Some(level.into()),
+                LoggerProp::Tag(tag) => self.tag = Some(tag.value()),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Because a more convenient way of metaprogramming in rust related to proc_macro, I tried to replace `ndk_glue` macro with attribute procedural macro (`main`) which applied directly to main function.

* Enabling backtraces using env-var isn't default behavior now and can be done using `backtrace` property.
* Added `logger` property which configures _android_logger_ before entering to
main function.