### PR TITLE
Added support for `backtrace(full)` in `ndk-glue::macro`

### DIFF
--- a/ndk-macro/src/expand.rs
+++ b/ndk-macro/src/expand.rs
@@ -108,6 +108,31 @@ mod test {
         assert_eq!(actual.to_string(), expected.to_string());
     }
 
+    #[test]
+    fn main_with_backtrace_prop_full() {
+        let attr = parse_quote! { backtrace(full) };
+        let item = parse_quote! { fn main() {} };
+        let actual = main(&attr, &item);
+        let expected = quote! {
+            #[no_mangle]
+            unsafe extern "C" fn ANativeActivity_onCreate(
+                activity: *mut std::os::raw::c_void,
+                saved_state: *mut std::os::raw::c_void,
+                saved_state_size: usize,
+            ) {
+                std::env::set_var("RUST_BACKTRACE", "full");
+                ndk_glue::init(
+                    activity as _,
+                    saved_state as _,
+                    saved_state_size as _,
+                    main,
+                );
+            }
+            fn main() {}
+        };
+        assert_eq!(actual.to_string(), expected.to_string());
+    }
+
     #[cfg(feature = "logger")]
     mod logger {
         use super::*;

--- a/ndk-macro/src/expand/backtrace.rs
+++ b/ndk-macro/src/expand/backtrace.rs
@@ -5,10 +5,9 @@ use crate::parse::MainAttr;
 
 impl MainAttr {
     pub fn expand_backtrace(&self) -> Option<TokenStream> {
-        if self.backtrace_enabled() {
-            Some(quote! { std::env::set_var("RUST_BACKTRACE", "1"); })
-        } else {
-            None
-        }
+        self.backtrace_config().map(|config| {
+            let config: String = config.as_ref().into();
+            quote! { std::env::set_var("RUST_BACKTRACE", #config); }
+        })
     }
 }

--- a/ndk-macro/src/parse.rs
+++ b/ndk-macro/src/parse.rs
@@ -69,7 +69,7 @@ mod test {
         let attr: MainAttr = parse_quote! {};
 
         assert_eq!(attr.props.len(), 0);
-        assert!(!attr.backtrace_enabled());
+        assert_eq!(attr.backtrace_config(), None);
     }
 
     #[should_panic]
@@ -79,19 +79,35 @@ mod test {
     }
 
     #[test]
-    fn single_backtrace_prop() {
+    fn single_backtrace_prop_without_props() {
         let attr: MainAttr = parse_quote! { backtrace };
 
         assert_eq!(attr.props.len(), 1);
-        assert!(attr.backtrace_enabled());
+        assert_eq!(attr.backtrace_config(), Some(BacktraceConfig::On));
     }
 
     #[test]
-    fn repeated_backtrace_props() {
+    fn single_backtrace_prop_with_full_prop() {
+        let attr: MainAttr = parse_quote! { backtrace(full) };
+
+        assert_eq!(attr.props.len(), 1);
+        assert_eq!(attr.backtrace_config(), Some(BacktraceConfig::Full));
+    }
+
+    #[test]
+    fn repeated_backtrace_props_without_props() {
         let attr: MainAttr = parse_quote! { backtrace, backtrace };
 
         assert_eq!(attr.props.len(), 2);
-        assert!(attr.backtrace_enabled());
+        assert_eq!(attr.backtrace_config(), Some(BacktraceConfig::On));
+    }
+
+    #[test]
+    fn repeated_backtrace_props_with_props() {
+        let attr: MainAttr = parse_quote! { backtrace, backtrace(full) };
+
+        assert_eq!(attr.props.len(), 2);
+        assert_eq!(attr.backtrace_config(), Some(BacktraceConfig::Full));
     }
 
     #[cfg(feature = "logger")]
@@ -139,7 +155,7 @@ mod test {
             let attr: MainAttr = parse_quote! { logger(error, "my-app"), backtrace };
 
             assert_eq!(attr.props.len(), 2);
-            assert!(attr.backtrace_enabled());
+            assert_eq!(attr.backtrace_config(), Some(BacktraceConfig::On));
 
             let config = attr.logger_config().unwrap();
 

--- a/ndk-macro/src/parse/backtrace.rs
+++ b/ndk-macro/src/parse/backtrace.rs
@@ -1,44 +1,107 @@
 use syn::{
+    parenthesized,
     parse::{Parse, ParseStream},
-    Result,
+    punctuated::Punctuated,
+    token::Paren,
+    Result, Token,
 };
 
-use super::MainAttr;
+use super::{MainAttr, MainProp};
 
 pub mod keyword {
     use syn::custom_keyword as kw;
 
     kw!(backtrace);
+    kw!(full);
 }
 
 impl MainAttr {
-    pub fn backtrace_enabled(&self) -> bool {
-        #[cfg(not(feature = "logger"))]
-        {
-            !self.props.is_empty()
-        }
-
-        #[cfg(feature = "logger")]
-        self.props.iter().any(|prop| {
-            use super::MainProp;
-            if let MainProp::Backtrace { .. } = prop {
-                true
-            } else {
-                false
+    pub fn backtrace_config(&self) -> Option<BacktraceConfig> {
+        let mut config = None;
+        for prop in &self.props {
+            #[allow(irrefutable_let_patterns)]
+            if let MainProp::Backtrace(MainPropBacktrace { ref props, .. }) = prop {
+                if config.is_none() {
+                    config = Some(BacktraceConfig::default());
+                }
+                config.as_mut().unwrap().merge(props);
             }
-        })
+        }
+        config
     }
 }
 
 pub struct MainPropBacktrace {
     #[allow(unused)]
     key: keyword::backtrace,
+    #[allow(unused)]
+    paren: Option<Paren>,
+    props: Punctuated<BacktraceProp, Token![,]>,
 }
 
 impl Parse for MainPropBacktrace {
     fn parse(input: ParseStream) -> Result<Self> {
-        Ok(Self {
-            key: input.parse()?,
-        })
+        let key = input.parse()?;
+
+        let (paren, props) = if input.peek(Paren) {
+            let content;
+            (
+                Some(parenthesized!(content in input)),
+                Punctuated::parse_terminated(&content)?,
+            )
+        } else {
+            (None, Punctuated::default())
+        };
+        Ok(Self { key, paren, props })
+    }
+}
+
+pub enum BacktraceProp {
+    Full(keyword::full),
+}
+
+impl Parse for BacktraceProp {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(keyword::full) {
+            Ok(BacktraceProp::Full(input.parse()?))
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BacktraceConfig {
+    On,
+    Full,
+}
+
+impl Default for BacktraceConfig {
+    fn default() -> Self {
+        Self::On
+    }
+}
+
+impl<'a> From<&'a BacktraceProp> for BacktraceConfig {
+    fn from(_prop: &BacktraceProp) -> Self {
+        Self::Full
+    }
+}
+
+impl AsRef<str> for BacktraceConfig {
+    fn as_ref(&self) -> &str {
+        match self {
+            BacktraceConfig::On => "1",
+            BacktraceConfig::Full => "full",
+        }
+    }
+}
+
+impl BacktraceConfig {
+    pub fn merge(&mut self, props: &Punctuated<BacktraceProp, Token![,]>) {
+        for prop in props {
+            *self = prop.into();
+        }
     }
 }


### PR DESCRIPTION
I have missing it in #37.