### PR TITLE
Specify assets directory via fully-qualified path

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,12 +17,18 @@ jobs:
         ]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Download NDK
       run: |
         curl -LO https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip
         unzip android-ndk-r20-linux-x86_64.zip -d $GITHUB_WORKSPACE
+
+    - name: Setup java
+      uses: actions/setup-java@v1
+      with:
+        java-package: jre # Runtime new enough for android toolchain
+        java-version: '13'
 
     - name: Installing Rust ${{ matrix.rust-channel }} w/ ${{ matrix.rust-target }}
       uses: actions-rs/toolchain@v1
@@ -31,8 +37,14 @@ jobs:
         target: ${{ matrix.rust-target }}
         override: true
 
-    - name: Check formating
-      run: cargo fmt --all -- --check
+    - name: Install components
+      run: rustup component add --toolchain ${{ matrix.rust-channel }} rustfmt
+
+    - name: Format
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
 
     - name: Run tests
       run: |

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -58,7 +58,13 @@ impl<'a> ApkBuilder<'a> {
             split: None,
             target_name: artifact.name().replace("-", "_"),
             debuggable: *self.cmd.profile() == Profile::Dev,
-            assets: self.manifest.assets.clone(),
+            assets: self.manifest.assets.as_ref().map(|assets| {
+               self.cmd
+                    .manifest()
+                    .parent()
+                    .expect("invalid manifest path")
+                    .join(&assets)
+            }),
             res: self.manifest.res.clone(),
         };
         let config = ApkConfig::from_config(config, self.manifest.metadata.clone());

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -59,7 +59,7 @@ impl<'a> ApkBuilder<'a> {
             target_name: artifact.name().replace("-", "_"),
             debuggable: *self.cmd.profile() == Profile::Dev,
             assets: self.manifest.assets.as_ref().map(|assets| {
-               self.cmd
+                self.cmd
                     .manifest()
                     .parent()
                     .expect("invalid manifest path")

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 pub struct ApkConfig {
     pub ndk: Ndk,
     pub build_dir: PathBuf,
-    pub assets: Option<String>,
+    pub assets: Option<PathBuf>,
     pub res: Option<String>,
     pub manifest: Manifest,
 }
@@ -99,7 +99,7 @@ impl ApkConfig {
         }
 
         if let Some(assets) = &self.assets {
-            aapt.arg("-A").arg(assets);
+            aapt.arg("-A").arg(dunce::simplified(assets));
         }
 
         if !aapt.status()?.success() {

--- a/ndk-build/src/config.rs
+++ b/ndk-build/src/config.rs
@@ -14,7 +14,7 @@ pub struct Config {
     pub split: Option<String>,
     pub target_name: String,
     pub debuggable: bool,
-    pub assets: Option<String>,
+    pub assets: Option<PathBuf>,
     pub res: Option<String>,
 }
 

--- a/ndk/src/asset.rs
+++ b/ndk/src/asset.rs
@@ -58,7 +58,7 @@ impl AssetManager {
 ///
 /// ```no_run
 /// # use std::ffi::CString;
-/// # use android_ndk::asset::AssetManager;
+/// # use ndk::asset::AssetManager;
 /// # let asset_manager: AssetManager = unimplemented!();
 /// use std::io::Read;
 ///
@@ -143,7 +143,7 @@ impl Iterator for AssetDir {
 ///
 /// ```no_run
 /// # use std::ffi::CString;
-/// # use android_ndk::asset::AssetManager;
+/// # use ndk::asset::AssetManager;
 /// # let asset_manager: AssetManager = unimplemented!();
 /// use std::io::Read;
 ///

--- a/ndk/src/native_activity.rs
+++ b/ndk/src/native_activity.rs
@@ -87,7 +87,7 @@ impl NativeActivity {
     ///
     /// Usage with [__jni__](https://crates.io/crates/jni) crate:
     /// ```no_run
-    /// # use android_ndk::native_activity::NativeActivity;
+    /// # use ndk::native_activity::NativeActivity;
     /// # let native_activity: NativeActivity = unimplemented!();
     /// let vm_ptr = native_activity.vm();
     /// let vm = unsafe { jni::JavaVM::from_raw(vm_ptr) }.unwrap();
@@ -97,7 +97,7 @@ impl NativeActivity {
     ///
     /// Usage with [__jni-glue__](https://crates.io/crates/jni-glue) crate:
     /// ```no_run
-    /// # use android_ndk::native_activity::NativeActivity;
+    /// # use ndk::native_activity::NativeActivity;
     /// # let native_activity: NativeActivity = unimplemented!();
     /// let vm_ptr = native_activity.vm();
     /// let vm = unsafe { jni_glue::VM::from_jni_local(&*vm_ptr) };


### PR DESCRIPTION
The working directory is for the `aapt` packing command is set to the target directory while the assets directory path from the manifest is just forwarded. This results in the android tool to not find the directory.

Tested locally on Windows.