### PR TITLE
Drop failure for anyhow, derive Error impls using thiserror

### DIFF
--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -11,10 +11,10 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
+anyhow = "1.0"
 cargo-subcommand = "0.4.4"
 dunce = "1.0"
 env_logger = "0.7.1"
-exitfailure = "0.5.1"
 log = "0.4.8"
 ndk-build = { path = "../ndk-build", version = "0.1" }
 serde = "1.0.104"

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -18,4 +18,5 @@ env_logger = "0.7.1"
 log = "0.4.8"
 ndk-build = { path = "../ndk-build", version = "0.1" }
 serde = "1.0.104"
+thiserror = "1.0"
 toml = "0.5.6"

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -24,12 +24,10 @@ impl<'a> ApkBuilder<'a> {
         let manifest = Manifest::parse_from_toml(cmd.manifest())?;
         let build_targets = if let Some(target) = cmd.target() {
             vec![Target::from_rust_triple(target)?]
+        } else if !manifest.build_targets.is_empty() {
+            manifest.build_targets.clone()
         } else {
-            if manifest.build_targets.len() > 0 {
-                manifest.build_targets.clone()
-            } else {
-                vec![ndk.detect_abi().unwrap_or(Target::Arm64V8a)]
-            }
+            vec![ndk.detect_abi().unwrap_or(Target::Arm64V8a)]
         };
         let build_dir = dunce::simplified(cmd.target_dir())
             .join(cmd.profile())

--- a/cargo-apk/src/error.rs
+++ b/cargo-apk/src/error.rs
@@ -1,56 +1,23 @@
 use cargo_subcommand::Error as SubcommandError;
 use ndk_build::error::NdkError;
-use std::fmt::{Display, Formatter, Result};
 use std::io::Error as IoError;
+use thiserror::Error;
 use toml::de::Error as TomlError;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
-    Subcommand(SubcommandError),
-    Config(TomlError),
-    Ndk(NdkError),
-    Io(IoError),
+    #[error(transparent)]
+    Subcommand(#[from] SubcommandError),
+    #[error("Failed to parse config.")]
+    Config(#[from] TomlError),
+    #[error(transparent)]
+    Ndk(#[from] NdkError),
+    #[error(transparent)]
+    Io(#[from] IoError),
 }
 
 impl Error {
     pub fn invalid_args() -> Self {
         Self::Subcommand(SubcommandError::InvalidArgs)
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        match self {
-            Self::Subcommand(error) => error.fmt(f),
-            Self::Config(error) => return write!(f, "Failed to parse config: {}.", error),
-            Self::Ndk(error) => error.fmt(f),
-            Self::Io(error) => error.fmt(f),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
-
-impl From<SubcommandError> for Error {
-    fn from(error: SubcommandError) -> Self {
-        Self::Subcommand(error)
-    }
-}
-
-impl From<TomlError> for Error {
-    fn from(error: TomlError) -> Self {
-        Self::Config(error)
-    }
-}
-
-impl From<NdkError> for Error {
-    fn from(error: NdkError) -> Self {
-        Self::Ndk(error)
-    }
-}
-
-impl From<IoError> for Error {
-    fn from(error: IoError) -> Self {
-        Self::Io(error)
     }
 }

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    let cmd = Subcommand::new("apk", |_, _| Ok(false)).map_err(|e| Error::Subcommand(e))?;
+    let cmd = Subcommand::new("apk", |_, _| Ok(false)).map_err(Error::Subcommand)?;
     let builder = ApkBuilder::from_subcommand(&cmd)?;
 
     match cmd.cmd() {

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -1,9 +1,8 @@
 use cargo_apk::{ApkBuilder, Error};
 use cargo_subcommand::Subcommand;
-use exitfailure::ExitDisplay;
 use std::process::Command;
 
-fn main() -> Result<(), ExitDisplay<Error>> {
+fn main() -> anyhow::Result<()> {
     env_logger::init();
 
     let cmd = Subcommand::new("apk", |_, _| Ok(false)).map_err(|e| Error::Subcommand(e))?;
@@ -16,21 +15,15 @@ fn main() -> Result<(), ExitDisplay<Error>> {
             }
         }
         "run" => {
-            if cmd.artifacts().len() == 1 {
-                builder.run(&cmd.artifacts()[0])?;
-            } else {
-                return Err(Error::invalid_args().into());
-            }
+            anyhow::ensure!(cmd.artifacts().len() == 1, Error::invalid_args());
+            builder.run(&cmd.artifacts()[0])?;
         }
         "--" => {
             builder.default()?;
         }
         "gdb" => {
-            if cmd.artifacts().len() == 1 {
-                builder.gdb(&cmd.artifacts()[0])?;
-            } else {
-                return Err(Error::invalid_args().into());
-            }
+            anyhow::ensure!(cmd.artifacts().len() == 1, Error::invalid_args());
+            builder.gdb(&cmd.artifacts()[0])?;
         }
         "help" => {
             if let Some(arg) = cmd.args().get(0) {

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -14,4 +14,5 @@ repository = "https://github.com/rust-windowing/android-ndk-rs"
 dirs = "2.0.2"
 dunce = "1.0"
 serde = { version = "1.0.104", features = ["derive"] }
+thiserror = "1.0"
 which = "4.0"

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -14,4 +14,4 @@ repository = "https://github.com/rust-windowing/android-ndk-rs"
 dirs = "2.0.2"
 dunce = "1.0"
 serde = { version = "1.0.104", features = ["derive"] }
-which = "3.1.0"
+which = "4.0"

--- a/ndk-build/src/config.rs
+++ b/ndk-build/src/config.rs
@@ -92,7 +92,7 @@ impl From<IntentFilterConfig> for IntentFilter {
             data: config
                 .data
                 .into_iter()
-                .map(|d| IntentFilterData::from(d))
+                .map(IntentFilterData::from)
                 .rev()
                 .collect(),
             categories: config.categories,

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -69,7 +69,7 @@ impl Ndk {
             })
             .collect();
 
-        if platforms.len() < 1 {
+        if platforms.is_empty() {
             return Err(NdkError::NoPlatformFound);
         }
 
@@ -220,7 +220,7 @@ impl Ndk {
 
     pub fn android_dir(&self) -> Result<PathBuf, NdkError> {
         let android_dir = dirs::home_dir()
-            .ok_or(NdkError::PathNotFound(PathBuf::from("$HOME")))?
+            .ok_or_else(|| NdkError::PathNotFound(PathBuf::from("$HOME")))?
             .join(".android");
         std::fs::create_dir_all(&android_dir)?;
         Ok(android_dir)

--- a/ndk-build/src/readelf.rs
+++ b/ndk-build/src/readelf.rs
@@ -71,7 +71,7 @@ fn list_needed_libs(readelf_path: &Path, library_path: &Path) -> Result<HashSet<
             let lib = line
                 .split("Shared library: [")
                 .last()
-                .and_then(|line| line.split("]").next());
+                .and_then(|line| line.split(']').next());
             if let Some(lib) = lib {
                 needed.insert(lib.to_string());
             }

--- a/ndk-glue/src/lib.rs
+++ b/ndk-glue/src/lib.rs
@@ -158,10 +158,8 @@ pub unsafe fn init(
             if let Ok(len) = reader.read_line(&mut buffer) {
                 if len == 0 {
                     break;
-                } else {
-                    if let Ok(msg) = CString::new(buffer.clone()) {
-                        android_log(Level::Info, tag, &msg);
-                    }
+                } else if let Ok(msg) = CString::new(buffer.clone()) {
+                    android_log(Level::Info, tag, &msg);
                 }
             }
         }

--- a/ndk/src/aaudio.rs
+++ b/ndk/src/aaudio.rs
@@ -190,7 +190,7 @@ impl AAudioErrorResult {
 pub enum AAudioError {
     #[error("error AAudio result ({0:?})")]
     ErrorResult(AAudioErrorResult),
-    #[error("unknown AAudio result value ({0})")]
+    #[error("unknown AAudio error result ({0})")]
     UnknownResult(i32),
     #[error("unsupported AAudio result value received ({0})")]
     UnsupportedValue(i32),
@@ -229,7 +229,7 @@ impl AAudioError {
 
 pub type Result<T, E = AAudioError> = std::result::Result<T, E>;
 
-fn construct<T>(with_ptr: impl FnOnce(*mut T) -> ffi::camera_status_t) -> Result<T> {
+fn construct<T>(with_ptr: impl FnOnce(*mut T) -> ffi::aaudio_result_t) -> Result<T> {
     let mut result = MaybeUninit::uninit();
     let status = with_ptr(result.as_mut_ptr());
     AAudioError::from_result(status, || unsafe { result.assume_init() })
@@ -272,7 +272,7 @@ impl fmt::Debug for AAudioStreamBuilder {
 
 pub type AudioStreamDataCallback =
     Box<dyn FnMut(&AAudioStream, *mut c_void, i32) -> AAudioCallbackResult>;
-pub type AudioStreamErrorCallback = Box<dyn FnMut(&AAudioStream, AAudioError) -> ()>;
+pub type AudioStreamErrorCallback = Box<dyn FnMut(&AAudioStream, AAudioError)>;
 
 impl AAudioStreamBuilder {
     fn from_ptr(inner: NonNull<ffi::AAudioStreamBuilder>) -> Self {

--- a/ndk/src/input_queue.rs
+++ b/ndk/src/input_queue.rs
@@ -38,7 +38,7 @@ impl InputQueue {
             if ffi::AInputQueue_getEvent(self.ptr.as_ptr(), &mut out_event) < 0 {
                 None
             } else {
-                debug_assert!(out_event != ptr::null_mut());
+                debug_assert!(!out_event.is_null());
                 Some(InputEvent::from_ptr(NonNull::new_unchecked(out_event)))
             }
         }

--- a/ndk/src/looper.rs
+++ b/ndk/src/looper.rs
@@ -8,12 +8,12 @@
 //!  * `ForeignLooper`, which has methods for the operations performable with any thread's looper.
 
 use std::convert::TryInto;
-use std::fmt;
 use std::os::raw::c_void;
 use std::os::unix::io::RawFd;
 use std::ptr;
 use std::ptr::NonNull;
 use std::time::Duration;
+use thiserror::Error;
 
 /// A thread-local `ALooper`.  This contains a native `ALooper *` and promises that there is a
 /// looper associated with the current thread.
@@ -41,16 +41,9 @@ pub enum Poll {
     },
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Error)]
+#[error("Android Looper error")]
 pub struct LooperError;
-
-impl fmt::Display for LooperError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Android Looper error")
-    }
-}
-
-impl std::error::Error for LooperError {}
 
 impl ThreadLooper {
     /// Prepares a looper for the current thread and returns it


### PR DESCRIPTION
fixes #16

before (cargo tree --invert failure):
```
failure v0.1.8
├── exitfailure v0.5.1
│   └── cargo-apk v0.5.1 (/home/jadsu/git/android-ndk-rs/cargo-apk)
└── which v3.1.1
    └── ndk-build v0.1.1 (/home/jadsu/git/android-ndk-rs/ndk-build)
        └── cargo-apk v0.5.1 (/home/jadsu/git/android-ndk-rs/cargo-apk)
```
        
after:
`error: package ID specification 'failure' matched no packages`

* Replaced some Error/Display impls with `thiserror`
* Fixed small clippy nits, remaining issues are now mainly missing native function safety docs.
