### PR TITLE
Remove android_log-sys dependency

### DIFF
--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -12,7 +12,6 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
-android_log-sys = "0.1.2"
 ndk = { path = "../ndk", version = "0.1.1" }
 ndk-sys = { path = "../ndk-sys", version = "0.1.1" }
 ndk-macro = { path = "../ndk-macro", version = "0.1.0" }

--- a/ndk-glue/src/lib.rs
+++ b/ndk-glue/src/lib.rs
@@ -17,20 +17,15 @@ use std::thread;
 pub use ndk_macro::main;
 
 pub fn android_log(level: Level, tag: &CStr, msg: &CStr) {
-    use android_log_sys::LogPriority;
     let prio = match level {
-        Level::Error => LogPriority::ERROR,
-        Level::Warn => LogPriority::WARN,
-        Level::Info => LogPriority::INFO,
-        Level::Debug => LogPriority::DEBUG,
-        Level::Trace => LogPriority::VERBOSE,
+        Level::Error => ndk_sys::android_LogPriority_ANDROID_LOG_ERROR,
+        Level::Warn => ndk_sys::android_LogPriority_ANDROID_LOG_WARN,
+        Level::Info => ndk_sys::android_LogPriority_ANDROID_LOG_INFO,
+        Level::Debug => ndk_sys::android_LogPriority_ANDROID_LOG_DEBUG,
+        Level::Trace => ndk_sys::android_LogPriority_ANDROID_LOG_VERBOSE,
     };
     unsafe {
-        android_log_sys::__android_log_write(
-            prio as _,
-            tag.as_ptr() as *const _,
-            msg.as_ptr() as *const _,
-        );
+        ndk_sys::__android_log_write(prio as raw::c_int, tag.as_ptr(), msg.as_ptr());
     }
 }
 


### PR DESCRIPTION
Since we generate these bindings in ndk-sys anyhow, there's no need for this crate. That's one less dependency when the "logger" feature is not used.