### PR TITLE
Add screenOrientation configuration via metadata

### DIFF
--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -44,6 +44,12 @@ fullscreen = false
 # Defaults to [3, 1]
 opengles_version = [3, 0]
 
+# Sets the applications screenOrientation.
+# See https://developer.android.com/guide/topics/manifest/activity-element
+# and look for `a`ndroid:screenOrientation` for possible values
+# Defaults to "unspecified"
+orientation = "sensorLandscape"
+
 # Adds a uses-feature element to the manifest
 # Supported keys: name, required
 # See https://developer.android.com/guide/topics/manifest/uses-feature-element

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -46,8 +46,9 @@ opengles_version = [3, 0]
 
 # Sets the applications screenOrientation.
 # See https://developer.android.com/guide/topics/manifest/activity-element
-# and look for `a`ndroid:screenOrientation` for possible values
-# Defaults to "unspecified"
+# and look for `android:screenOrientation` for possible values
+# Defaults to "unspecified" which makes the system pick an orientation and
+# doesn't give you help with rotation.
 orientation = "sensorLandscape"
 
 # Adds a uses-feature element to the manifest

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -60,6 +60,7 @@ impl ApkConfig {
             intent_filters,
             icon: metadata.icon,
             fullscreen: metadata.fullscreen.unwrap_or(false),
+            orientation: metadata.orientation,
             application_metadatas,
         };
         Self {

--- a/ndk-build/src/config.rs
+++ b/ndk-build/src/config.rs
@@ -24,6 +24,7 @@ pub struct Metadata {
     pub min_sdk_version: Option<u32>,
     pub icon: Option<String>,
     pub fullscreen: Option<bool>,
+    pub orientation: Option<String>,
     pub opengles_version: Option<(u8, u8)>,
     pub feature: Option<Vec<FeatureConfig>>,
     pub permission: Option<Vec<PermissionConfig>>,

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -18,6 +18,7 @@ pub struct Manifest {
     pub intent_filters: Vec<IntentFilter>,
     pub icon: Option<String>,
     pub fullscreen: bool,
+    pub orientation: Option<String>,
     pub debuggable: bool,
     pub split: Option<String>,
     pub application_metadatas: Vec<ApplicationMetadata>,
@@ -43,6 +44,12 @@ impl Manifest {
             r#"android:theme="@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen""#
         } else {
             ""
+        };
+
+        let orientation = if let Some(orient) = self.orientation.as_ref() {
+            orient
+        } else {
+            "unspecified"
         };
 
         let features: Vec<String> = self.features.iter().map(|f| f.to_string()).collect();
@@ -78,6 +85,7 @@ impl Manifest {
         <activity
                 android:name="android.app.NativeActivity"
                 android:label="{package_label}"
+                android:screenOrientation="{orientation}"
                 android:configChanges="orientation|keyboardHidden|screenSize">
             <meta-data android:name="android.app.lib_name" android:value="{target_name}" />
             <intent-filter>
@@ -99,6 +107,7 @@ impl Manifest {
             target_name = &self.target_name,
             icon = icon,
             fullscreen = fullscreen,
+            orientation = orientation,
             application_metadatas = application_metadatas.join("\n"),
             debuggable = self.debuggable,
             features = features.join("\n"),

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -46,11 +46,7 @@ impl Manifest {
             ""
         };
 
-        let orientation = if let Some(orient) = self.orientation.as_ref() {
-            orient
-        } else {
-            "unspecified"
-        };
+        let orientation = self.orientation.as_deref().unwrap_or("unspecified");
 
         let features: Vec<String> = self.features.iter().map(|f| f.to_string()).collect();
         let permissions: Vec<String> = self.permissions.iter().map(|p| p.to_string()).collect();


### PR DESCRIPTION
Allows changing the orientation of the screen by setting `android:screenOrientation` in the manifest. It might be worth adding to the cargo-apk readme that the default value of "unspecified" doesn't do any rotation for you at all, but "sensorLandscape" and "sensorPortrait" allow rotation from their normal orientations and their reverse orientations.