### PR TITLE
Allow change apk label with apk_label in metadata

### DIFF
--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -26,6 +26,9 @@ cargo install --path .
 Following configuration options are supported by `cargo apk` under `[package.metadata.android]`:
 
 ```toml
+# Name of your APK as shown in the app drawer and in the app switcher
+apk_label = "APK Name"
+
 # The target Android API level.
 target_sdk_version = 29
 min_sdk_version = 26

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -47,11 +47,16 @@ impl<'a> ApkBuilder<'a> {
             Artifact::Root(name) => format!("rust.{}", name.replace("-", "_")),
             Artifact::Example(name) => format!("rust.example.{}", name.replace("-", "_")),
         };
+        let package_label = self.manifest.metadata.apk_label
+            .as_deref()
+            .unwrap_or(artifact.name())
+            .to_string();
+
         let config = Config {
             ndk: self.ndk.clone(),
             build_dir: self.build_dir.join(artifact),
             package_name,
-            package_label: artifact.name().to_string(),
+            package_label,
             version_name: self.manifest.version.clone(),
             version_code: VersionCode::from_semver(&self.manifest.version)?.to_code(1),
             split: None,

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -47,7 +47,10 @@ impl<'a> ApkBuilder<'a> {
             Artifact::Root(name) => format!("rust.{}", name.replace("-", "_")),
             Artifact::Example(name) => format!("rust.example.{}", name.replace("-", "_")),
         };
-        let package_label = self.manifest.metadata.apk_label
+        let package_label = self
+            .manifest
+            .metadata
+            .apk_label
             .as_deref()
             .unwrap_or(artifact.name())
             .to_string();

--- a/ndk-build/src/config.rs
+++ b/ndk-build/src/config.rs
@@ -20,6 +20,7 @@ pub struct Config {
 
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct Metadata {
+    pub apk_label: Option<String>,
     pub target_sdk_version: Option<u32>,
     pub min_sdk_version: Option<u32>,
     pub icon: Option<String>,


### PR DESCRIPTION
Allows you to change the label of your APK using the metadata in your Cargo.toml. Hope this is useful!