### PR TITLE
CI publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   Publish:
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       max-parallel: 1 # ensure crate order
       fail-fast: false
@@ -31,4 +32,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: publish
-        args: --manifest-path ${{ matrix.crate }}/Cargo.toml --dry-run --target ${{ matrix.rust-target }} --token ${{ secrets.cratesio_token }}
+        args: --manifest-path ${{ matrix.crate }}/Cargo.toml --target ${{ matrix.rust-target }} --token ${{ secrets.cratesio_token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish
+
+on:
+  push:
+    branches: [master]
+    paths: "**/Cargo.toml"
+
+jobs:
+  Publish:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1 # ensure crate order
+      fail-fast: false
+      matrix:
+        crate: [
+            'ndk-sys',
+            'ndk',
+            'ndk-glue',
+            'ndk-build',
+            'cargo-apk',
+        ]
+        rust-target: [ 'armv7-linux-androideabi' ]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.rust-target }}
+        override: true
+    - name: Publish ${{ matrix.crate }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: publish
+        args: --manifest-path ${{ matrix.crate }}/Cargo.toml --dry-run --target ${{ matrix.rust-target }} --token ${{ secrets.cratesio_token }}

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-glue"
-version = "0.1.1"
+version = "0.1.0"
 authors = ["David Craven <david@craven.ch>"]
 edition = "2018"
 description = "Startup code for android binaries"
@@ -12,8 +12,8 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
-ndk = { path = "../ndk", version = "0.1.1" }
-ndk-sys = { path = "../ndk-sys", version = "0.1.1" }
+ndk = { path = "../ndk", version = "0.1.0" }
+ndk-sys = { path = "../ndk-sys", version = "0.1.0" }
 ndk-macro = { path = "../ndk-macro", version = "0.1.0" }
 lazy_static = "1.4.0"
 libc = "0.2.66"

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-sys"
-version = "0.1.1"
+version = "0.1.0"
 authors = ["Mark Barbone <mark.l.barbone@gmail.com>"]
 edition = "2018"
 description = "FFI bindings for the Android NDK"

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk"
-version = "0.1.1"
+version = "0.1.0"
 authors = ["Mark Barbone <mark.l.barbone@gmail.com>"]
 edition = "2018"
 description = "Safe Rust bindings to the Android NDK"
@@ -47,4 +47,4 @@ optional = true
 [dependencies.ffi]
 package = "ndk-sys"
 path = "../ndk-sys"
-version = "0.1.1"
+version = "0.1.0"


### PR DESCRIPTION
Replacement for https://github.com/rust-windowing/android-ndk-rs/pull/14
Automatically publish crates once the versions get bumped on the master

Reverts the old 0.1.1 version bumps which got yanked due to breaking compatibility
I'm not 100% this works atm, but I guess the secrets are setup already