### PR TITLE
Bump versions

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.5.1 (2020-09-15)
+
 - Updated to use [ndk-build 0.1.2](../ndk-build/CHANGELOG.md#012-2020-09-15)
 
 # 0.5.1 (2020-07-15)

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.5.1 (2020-09-15)
+# 0.5.2 (2020-09-15)
 
 - Updated to use [ndk-build 0.1.2](../ndk-build/CHANGELOG.md#012-2020-09-15)
 

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-apk"
-version = "0.5.1"
-authors = ["David Craven <david@craven.ch>"]
+version = "0.5.2"
+authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Helps cargo build apks"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ cargo-subcommand = "0.4.4"
 dunce = "1.0"
 env_logger = "0.7.1"
 log = "0.4.8"
-ndk-build = { path = "../ndk-build", version = "0.1" }
+ndk-build = { path = "../ndk-build", version = "0.1.2" }
 serde = "1.0.104"
 thiserror = "1.0"
 toml = "0.5.6"

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.1.2 (2020-09-15)
+
 - `android:label` is configurable.
 - Library search paths are much more intelligent.
 - `android:screenOrientation` is configurable.

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ndk-build"
-version = "0.1.1"
-authors = ["David Craven <david@craven.ch>"]
+version = "0.1.2"
+authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Utilities for building android binaries"
 license = "MIT OR Apache-2.0"

--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.2.0 (2020-09-15)
+
 - **Breaking:** Changed `main` macro attribute syntax
 
 # 0.1.0 (2020-04-22)

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ndk-glue"
-version = "0.1.0"
-authors = ["David Craven <david@craven.ch>"]
+version = "0.2.0"
+authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Startup code for android binaries"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
-ndk = { path = "../ndk", version = "0.1.0" }
-ndk-sys = { path = "../ndk-sys", version = "0.1.0" }
-ndk-macro = { path = "../ndk-macro", version = "0.1.0" }
+ndk = { path = "../ndk", version = "0.2.0" }
+ndk-sys = { path = "../ndk-sys", version = "0.2.0" }
+ndk-macro = { path = "../ndk-macro", version = "0.2.0" }
 lazy_static = "1.4.0"
 libc = "0.2.66"
 log = "0.4.8"

--- a/ndk-macro/CHANGELOG.md
+++ b/ndk-macro/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.2.0 (2020-09-15)
+
 - Added crate name override option
 - **Breaking:** Changed macro attribute syntax
 

--- a/ndk-macro/Cargo.toml
+++ b/ndk-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ndk-macro"
-version = "0.1.0"
-authors = ["K. <kayo@illumium.org>"]
+version = "0.2.0"
+authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Helper macros for android ndk"
 license = "MIT OR Apache-2.0"

--- a/ndk-sys/CHANGELOG.md
+++ b/ndk-sys/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 0.2.0 (2020-09-15)
+
+- **Breaking:** `onSaveInstanceState` signature corrected to take `outSize` as a `*mut size_t` instead of `*mut usize`.
 - Add `media` bindings
 - Add `bitmap` and `hardware_buffer` bindings
 - Add `aaudio` bindings

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ndk-sys"
-version = "0.1.0"
-authors = ["Mark Barbone <mark.l.barbone@gmail.com>"]
+version = "0.2.0"
+authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "FFI bindings for the Android NDK"
 license = "MIT OR Apache-2.0"

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 0.2.0 (2020-09-15)
+
+- **Breaking:** Updated to use [ndk-sys 0.2.0](../ndk-sys/CHANGELOG.md#020-2020-09-15)
 - Added `media` bindings
 - Added `bitmap` and `hardware_buffer` bindings
 - Added `aaudio` bindings

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ndk"
-version = "0.1.0"
-authors = ["Mark Barbone <mark.l.barbone@gmail.com>"]
+version = "0.2.0"
+authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Safe Rust bindings to the Android NDK"
 license = "MIT OR Apache-2.0"
@@ -47,4 +47,4 @@ optional = true
 [dependencies.ffi]
 package = "ndk-sys"
 path = "../ndk-sys"
-version = "0.1.0"
+version = "0.2.0"


### PR DESCRIPTION
Fixes #59

This bumps the minor version for `ndk`, `ndk-sys`, `ndk-glue`, and `ndk-macro`, and bumps the patch version for `cargo-apk` and `ndk-build`.

I've also changed all of the Cargo.toml `authors` fields to "The Rust Windowing contributors", keeping with the convention used in winit and gfx.