### PR TITLE
Fix res folder resolve

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix `res` folder resolve.
+
 # 0.5.2 (2020-09-15)
 
 - Updated to use [ndk-build 0.1.2](../ndk-build/CHANGELOG.md#012-2020-09-15)

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -72,7 +72,16 @@ impl<'a> ApkBuilder<'a> {
                     .expect("invalid manifest path")
                     .join(&assets)
             }),
-            res: self.manifest.res.clone(),
+            res: self.manifest.res.as_ref().map(|res| {
+                self.cmd
+                    .manifest()
+                    .parent()
+                    .expect("invalid manifest path")
+                    .join(&res)
+                    .to_str()
+                    .unwrap()
+                    .to_owned()
+            }),
         };
 
         let config = ApkConfig::from_config(config, self.manifest.metadata.clone());


### PR DESCRIPTION
Currently, there's an error if you try to specify the `res` folder in the project that running not from root Cargo.toml