### PR TITLE
Explicitly set docs.rs targets

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.5.3 (2020-10-15)
+
 - Fix `res` folder resolve.
 
 # 0.5.2 (2020-09-15)

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-apk"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Helps cargo build APKs"

--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.2.1 (2020-10-15)
+
+- Fix documentation build on docs.rs
+
 # 0.2.0 (2020-09-15)
 
 - **Breaking:** Removed `ndk_glue` macro in favor of new `main` attribute macro.

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -23,3 +23,11 @@ android_logger = { version = "0.8.6", optional = true }
 [features]
 default = []
 logger = ["android_logger", "ndk-macro/logger"]
+
+[package.metadata.docs.rs]
+targets = [
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android",
+]

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-glue"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Startup code for android binaries"

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -12,8 +12,8 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
-ndk = { path = "../ndk", version = "0.2.0" }
-ndk-sys = { path = "../ndk-sys", version = "0.2.0" }
+ndk = { path = "../ndk", version = "0.2.1" }
+ndk-sys = { path = "../ndk-sys", version = "0.2.1" }
 ndk-macro = { path = "../ndk-macro", version = "0.2.0" }
 lazy_static = "1.4.0"
 libc = "0.2.66"

--- a/ndk-sys/CHANGELOG.md
+++ b/ndk-sys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.2.1 (2020-10-15)
+
+- Fix documentation build on docs.rs
+
 # 0.2.0 (2020-09-15)
 
 - **Breaking:** `onSaveInstanceState` signature corrected to take `outSize` as a `*mut size_t` instead of `*mut usize`.

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-sys"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "FFI bindings for the Android NDK"

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -12,11 +12,15 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [features]
-rustdoc = []
 test = []
 aaudio = []
 bitmap = []
 media = []
 
 [package.metadata.docs.rs]
-features = ["rustdoc"]
+targets = [
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android",
+]

--- a/ndk-sys/src/lib.rs
+++ b/ndk-sys/src/lib.rs
@@ -17,12 +17,10 @@
 #[cfg(not(any(target_os = "android", feature = "test")))]
 compile_error!("android-ndk-sys only supports compiling for Android");
 
-#[cfg(
-    all(
-        any(target_os = "android", feature = "test"),
-        any(target_arch = "arm", target_arch = "armv7")
-    )
-)]
+#[cfg(all(
+    any(target_os = "android", feature = "test"),
+    any(target_arch = "arm", target_arch = "armv7")
+))]
 include!("ffi_arm.rs");
 
 #[cfg(all(any(target_os = "android", feature = "test"), target_arch = "aarch64"))]

--- a/ndk-sys/src/lib.rs
+++ b/ndk-sys/src/lib.rs
@@ -14,16 +14,15 @@
 // Test setup lints
 #![cfg_attr(test, allow(dead_code))]
 
-#[cfg(not(any(target_os = "android", feature = "test", feature = "rustdoc")))]
+#[cfg(not(any(target_os = "android", feature = "test")))]
 compile_error!("android-ndk-sys only supports compiling for Android");
 
-#[cfg(any(
+#[cfg(
     all(
         any(target_os = "android", feature = "test"),
         any(target_arch = "arm", target_arch = "armv7")
-    ),
-    feature = "rustdoc"
-))]
+    )
+)]
 include!("ffi_arm.rs");
 
 #[cfg(all(any(target_os = "android", feature = "test"), target_arch = "aarch64"))]

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.2.1 (2020-10-15)
+
+- Fix documentation build on docs.rs
+
 # 0.2.0 (2020-09-15)
 
 - **Breaking:** Updated to use [ndk-sys 0.2.0](../ndk-sys/CHANGELOG.md#020-2020-09-15)

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -12,8 +12,6 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [features]
-rustdoc = ["ffi/rustdoc", "jni", "jni-glue", "all"]
-
 all = ["aaudio", "bitmap", "hardware_buffer", "media", "trace", "api-level-30"]
 
 aaudio = ["ffi/aaudio", "api-level-26"]
@@ -27,9 +25,6 @@ api-level-24 = ["api-level-23"]
 api-level-26 = ["api-level-24"]
 api-level-29 = ["api-level-26"]
 api-level-30 = ["api-level-29"]
-
-[package.metadata.docs.rs]
-features = ["rustdoc"]
 
 [dependencies]
 num_enum = "0.4.2"
@@ -48,3 +43,12 @@ optional = true
 package = "ndk-sys"
 path = "../ndk-sys"
 version = "0.2.0"
+
+[package.metadata.docs.rs]
+features = ["jni", "jni-glue", "all"]
+targets = [
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android",
+]

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -42,7 +42,7 @@ optional = true
 [dependencies.ffi]
 package = "ndk-sys"
 path = "../ndk-sys"
-version = "0.2.0"
+version = "0.2.1"
 
 [package.metadata.docs.rs]
 features = ["jni", "jni-glue", "all"]

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Safe Rust bindings to the Android NDK"


### PR DESCRIPTION
Only build for docs.rs targets and remove the `rustdoc` workaround

Fixes https://github.com/rust-windowing/android-ndk-rs/issues/80