### PR TITLE
ci: cache ndk download

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Cache NDK
+      id: cache-ndk
+      uses: actions/cache@v2
+      with:
+        path: android-ndk-r20
+        key: android-ndk-r20-${{ runner.os }}
+
     - name: Download NDK
+      if: steps.cache-ndk.outputs.cache-hit != 'true'
       run: |
         curl -LO https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip
         unzip android-ndk-r20-linux-x86_64.zip -d $GITHUB_WORKSPACE


### PR DESCRIPTION
curl download of the ndk seems to fail pretty frequently today at least causing the builds to fail most of the time.
This caches the ndk download which shoves off ~45sec from each build (which so far took 4-5min each)