### PR TITLE
Bump cargo-apk version to 0.5.4

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
+# 0.5.4 (2020-11-01)
+
 - Added support for activity metadata entries.
+- Fix glob member resolution in workspaces.
 
 # 0.5.3 (2020-10-15)
 

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-apk"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Helps cargo build APKs"


### PR DESCRIPTION
As requested by https://github.com/rust-windowing/android-ndk-rs/pull/85#issuecomment-719970447 for bevy