### PR TITLE
ci: Run all tests in isolation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,11 +59,22 @@ jobs:
         target: ${{ matrix.rust-target }}
         override: true
 
-    - name: Run tests
-      run: |
-        cd ndk-sys && cargo test --features test && cd ..
-        cd ndk && cargo test --features rustdoc --doc && cd ..
+    - name: Test ndk-sys
+      working-directory: ndk-sys
+      run:
+        cargo test --features test
+
+    - name: Test ndk
+      working-directory: ndk
+      run:
+        cargo test --features rustdoc --doc
+
+    - name: Test ndk-build
+      run:
         cargo test -p ndk-build
+
+    - name: Test cargo-apk
+      run:
         cargo test -p cargo-apk
 
     - name: Install cargo-apk

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,26 +60,24 @@ jobs:
         override: true
 
     - name: Test ndk-sys
-      working-directory: ndk-sys
       run:
-        cargo test --features test
+        cargo test -p ndk-sys --all-features
 
     - name: Test ndk
-      working-directory: ndk
       run:
-        cargo test --features test
+        cargo test -p ndk --all-features
 
     - name: Test ndk-build
       run:
-        cargo test -p ndk-build
+        cargo test -p ndk-build --all-features
 
     - name: Test ndk-macro
       run:
-        cargo test -p ndk-macro
+        cargo test -p ndk-macro --all-features
 
     - name: Test cargo-apk
       run:
-        cargo test -p cargo-apk
+        cargo test -p cargo-apk --all-features
 
     - name: Install cargo-apk
       run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,8 +65,9 @@ jobs:
         cargo test --features test
 
     - name: Test ndk
+      working-directory: ndk
       run:
-        cargo test -p ndk --doc
+        cargo test --features test
 
     - name: Test ndk-build
       run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,10 @@ jobs:
       run:
         cargo test -p ndk-build --all-features
 
+    - name: Test ndk-glue
+      run:
+        cargo test -p ndk-glue --all-features
+
     - name: Test ndk-macro
       run:
         cargo test -p ndk-macro --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,9 +65,8 @@ jobs:
         cargo test --features test
 
     - name: Test ndk
-      working-directory: ndk
       run:
-        cargo test --features rustdoc --doc
+        cargo test -p ndk --doc
 
     - name: Test ndk-build
       run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,10 @@ jobs:
       run:
         cargo test -p ndk-build
 
+    - name: Test ndk-macro
+      run:
+        cargo test -p ndk-macro
+
     - name: Test cargo-apk
       run:
         cargo test -p cargo-apk

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -22,6 +22,7 @@ android_logger = { version = "0.8.6", optional = true }
 
 [features]
 default = []
+test = ["ndk/test", "ndk-sys/test"]
 logger = ["android_logger", "ndk-macro/logger"]
 
 [package.metadata.docs.rs]

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -26,6 +26,8 @@ api-level-26 = ["api-level-24"]
 api-level-29 = ["api-level-26"]
 api-level-30 = ["api-level-29"]
 
+test = ["ffi/test", "jni", "jni-glue"]
+
 [dependencies]
 num_enum = "0.4.2"
 jni-sys = "0.3.0"

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -26,7 +26,7 @@ api-level-26 = ["api-level-24"]
 api-level-29 = ["api-level-26"]
 api-level-30 = ["api-level-29"]
 
-test = ["ffi/test", "jni", "jni-glue"]
+test = ["ffi/test", "jni", "jni-glue", "all"]
 
 [dependencies]
 num_enum = "0.4.2"


### PR DESCRIPTION
When using && to cd back out of a subdirectory the error code from cargo test is implicitly consumed instead of being caught by set -e.  While this does return a non-zero exit code it does not prevent the rest of the script from running if more lines follow.

The next lines run and, if successful, do not fail the step because GH actions base the result of a multiline shell script solely on the last command [1].

You can try this for yourself by throwing the following three steps in GH actions and observing the result [2]:

    false
    echo "This is not printed"

    false && echo "This is not printed"

    false && echo "This is not printed"
    echo "Oh noes, his is printed, and the script exits successfully"

In addition structuring the tests this way allows working-directory to be used, and shows every test individually in a PR to more quickly identify where things are going wrong.

[1]: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
[2]: https://github.com/MarijnS95/gh-actions-test/actions/runs/343934038