### PR TITLE
ci: Remove obsolete NDK/Java setup and run once on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,25 +33,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Cache NDK
-      id: cache-ndk
-      uses: actions/cache@v2
-      with:
-        path: android-ndk-r20
-        key: android-ndk-r20-${{ runner.os }}
-
-    - name: Download NDK
-      if: steps.cache-ndk.outputs.cache-hit != 'true'
-      run: |
-        curl -LO https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip
-        unzip android-ndk-r20-linux-x86_64.zip -d $GITHUB_WORKSPACE
-
-    - name: Setup java
-      uses: actions/setup-java@v1
-      with:
-        java-package: jre # Runtime new enough for android toolchain
-        java-version: '13'
-
     - name: Installing Rust ${{ matrix.rust-channel }} w/ ${{ matrix.rust-target }}
       uses: actions-rs/toolchain@v1
       with:
@@ -89,8 +70,5 @@ jobs:
 
     - name: Check compiling on target ${{ matrix.rust-target }}
       run: |
-        export NDK_HOME="$GITHUB_WORKSPACE/android-ndk-r20"
-        export CC="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
-        export AR="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
         cargo check -p ndk --target ${{ matrix.rust-target }}
         cargo apk build -p ndk-examples --target ${{ matrix.rust-target }} --examples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,8 +87,10 @@ jobs:
         echo "ANDROID_SDK_ROOT=$sdk_root" >> $env:GITHUB_ENV
         echo "ANDROID_NDK_ROOT=$sdk_root\ndk-bundle" >> $env:GITHUB_ENV
 
+        # Update legacy path for ndk-build:
+        echo "ANDROID_HOME=$sdk_root" >> $env:GITHUB_ENV
+
         # Unset legacy paths:
-        echo "ANDROID_HOME=" >> $env:GITHUB_ENV
         echo "ANDROID_NDK_HOME=" >> $env:GITHUB_ENV
         echo "ANDROID_NDK_PATH=" >> $env:GITHUB_ENV
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,17 +18,22 @@ jobs:
         args: --all -- --check
 
   build:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        os:  [ubuntu-latest]
         rust-channel: ['stable', 'nightly']
-        rust-target: [
-            'armv7-linux-androideabi',
-            'aarch64-linux-android',
-            'i686-linux-android',
-            'x86_64-linux-android',
-        ]
+        rust-target:
+          - 'armv7-linux-androideabi'
+          - 'aarch64-linux-android'
+          - 'i686-linux-android'
+          - 'x86_64-linux-android'
+        include:
+          - os: windows-latest
+            rust-channel: 'stable'
+            rust-target: 'aarch64-linux-android'
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
@@ -40,11 +45,13 @@ jobs:
         target: ${{ matrix.rust-target }}
         override: true
 
-    - name: Test ndk-sys
+    - if: runner.os != 'Windows'
+      name: Test ndk-sys
       run:
         cargo test -p ndk-sys --all-features
 
-    - name: Test ndk
+    - if: runner.os != 'Windows'
+      name: Test ndk
       run:
         cargo test -p ndk --all-features
 
@@ -52,11 +59,13 @@ jobs:
       run:
         cargo test -p ndk-build --all-features
 
-    - name: Test ndk-glue
+    - if: runner.os != 'Windows'
+      name: Test ndk-glue
       run:
         cargo test -p ndk-glue --all-features
 
-    - name: Test ndk-macro
+    - if: runner.os != 'Windows'
+      name: Test ndk-macro
       run:
         cargo test -p ndk-macro --all-features
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,6 +77,21 @@ jobs:
       run:
         cargo install --path cargo-apk
 
+    - if: runner.os == 'Windows'
+      name: Create symlink to Android SDK/NDK without spaces
+      run: |
+        $oldAndroidPath = $env:ANDROID_HOME
+        $sdk_root = "C:\Android"
+        New-Item -Path $sdk_root -ItemType SymbolicLink -Value $oldAndroidPath
+
+        echo "ANDROID_SDK_ROOT=$sdk_root" >> $env:GITHUB_ENV
+        echo "ANDROID_NDK_ROOT=$sdk_root\ndk-bundle" >> $env:GITHUB_ENV
+
+        # Unset legacy paths:
+        echo "ANDROID_HOME=" >> $env:GITHUB_ENV
+        echo "ANDROID_NDK_HOME=" >> $env:GITHUB_ENV
+        echo "ANDROID_NDK_PATH=" >> $env:GITHUB_ENV
+
     - name: Check compiling on target ${{ matrix.rust-target }}
       run: |
         cargo check -p ndk --target ${{ matrix.rust-target }}

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -17,7 +17,7 @@ impl Ndk {
             let mut sdk_path = std::env::var("ANDROID_HOME").ok();
             if sdk_path.is_some() {
                 println!(
-                    "Warning: You use environment variable ANDROID_HOME that is deprecated.\
+                    "Warning: You use environment variable ANDROID_HOME that is deprecated. \
                  Please, remove it and use ANDROID_SDK_ROOT instead. Now ANDROID_HOME is used"
                 );
             }


### PR DESCRIPTION
GitHub already includes the Android SDK/NDK and Java in their image, no need to download and install it again slowing down the build process.

Also run at least one build job on Windows to make sure it remains sane. It didn't seem necessary to run both nightly and stable for every target though.

Note that this is in part to bring to attention an issue with spaces in CC/LINKER paths:

```
error: linking with `C:\Program Files (x86)\Android\android-sdk\ndk-bundle\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android30-clang.cmd` failed: exit code: 1
  |
  = note: "C:\\Program Files (x86)\\Android\\android-sdk\\ndk-bundle\\toolchains\\llvm\\prebuilt\\windows-x86_64\\bin\\aarch64-linux-android30-clang.cmd" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-Wl,--allow-multiple-definition" "-Wl,--eh-frame-hdr" "-L" "C:\\Rust\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\aarch64-linux-android\\lib" [..]
  = note: 'C:\Program' is not recognized as an internal or external command,
          operable program or batch file.
```

It looks like the code using `CARGO_TARGET_aarch64_linux_android_LINKER` (though the same happens for `CC_/CCX_<triple>`) properly understands that that's one string (seeing the quotes in the log) yet somehow invokes it in the wrong way. Anyone have an idea where to look and resolve this?

(I'm not a fan of the `if: runner.os != 'Windows'` around most tests but we can't really run "Android-native" unix code on Windows)

EDIT: On the note of CC, how about including an [example/test](https://github.com/MarijnS95/android-ndk-rs/commit/compile-c) that validates native compilation?