### PR TITLE
ndk-build: Support NDK r22

### DIFF
--- a/ndk-build/src/dylibs.rs
+++ b/ndk-build/src/dylibs.rs
@@ -22,11 +22,11 @@ pub fn get_libs_search_paths(
             };
             for line in BufReader::new(File::open(output_file)?).lines() {
                 let line = line?;
-                if line.starts_with("cargo:rustc-link-search=") {
-                    let mut pie = line.split("=");
-                    let (kind, path) = match (pie.next(), pie.next(), pie.next()) {
-                        (Some(_), Some(kind), Some(path)) => (kind, path),
-                        (Some(_), Some(path), None) => ("all", path),
+                if let Some(link_search) = line.strip_prefix("cargo:rustc-link-search=") {
+                    let mut pie = link_search.split('=');
+                    let (kind, path) = match (pie.next(), pie.next()) {
+                        (Some(kind), Some(path)) => (kind, path),
+                        (Some(path), None) => ("all", path),
                         _ => unreachable!(),
                     };
                     match kind {

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -29,11 +29,11 @@ impl Ndk {
         };
 
         let ndk_path = {
-            let mut ndk_path = std::env::var("ANDROID_NDK_ROOT").ok();
-
-            if ndk_path.is_none() {
-                ndk_path = std::env::var("NDK_HOME").ok();
-            }
+            let ndk_path = std::env::var("ANDROID_NDK_ROOT")
+                .ok()
+                .or_else(|| std::env::var("ANDROID_NDK_PATH").ok())
+                .or_else(|| std::env::var("ANDROID_NDK_HOME").ok())
+                .or_else(|| std::env::var("NDK_HOME").ok());
 
             // default ndk installation path
             if ndk_path.is_none() && sdk_path.join("ndk-bundle").exists() {

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -63,12 +63,6 @@ impl Ndk {
                 name.strip_prefix("android-")
                     .and_then(|api| api.parse::<u32>().ok())
             })
-            .filter(|level| {
-                ndk_path
-                    .join("platforms")
-                    .join(format!("android-{}", level))
-                    .exists()
-            })
             .collect();
 
         if platforms.is_empty() {

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -59,8 +59,10 @@ impl Ndk {
             .filter_map(|path| path.ok())
             .filter(|path| path.path().is_dir())
             .filter_map(|path| path.file_name().into_string().ok())
-            .filter(|name| name.starts_with("android-"))
-            .filter_map(|name| name[8..].parse::<u32>().ok())
+            .filter_map(|name| {
+                name.strip_prefix("android-")
+                    .and_then(|api| api.parse::<u32>().ok())
+            })
             .filter(|level| {
                 ndk_path
                     .join("platforms")


### PR DESCRIPTION
`$ndk/platforms` is deprecated and finally removed in r22; android-ndk-rs was never using this so it's safe to remove.

If NDK platform compatibility checking is still desired, we should check for `$ndk/toolchains/${toolchain:-llvm}/prebuilt/${host:-linux-x86_64}/sysroot/usr/lib/$triple/$api/` (Linux ndk, might differ on other platforms) instead.

At the same time perform some minor code cleanup. How are the maintainers feeling about enabling `clippy` in the CI and fixing few remaining issues?