### PR TITLE
Added android:launchMode configurability

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.1.3 (2020-11-21)
+
+- Updated to use [ndk-build 0.1.3](../ndk-build/CHANGELOG.md#012-2020-11-21)
+
 # 0.5.4 (2020-11-01)
 
 - Added support for activity metadata entries.

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.1.3 (2020-11-21)
+# 0.5.5 (2020-11-21)
 
 - Updated to use [ndk-build 0.1.3](../ndk-build/CHANGELOG.md#012-2020-11-21)
 

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-apk"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Helps cargo build APKs"
@@ -16,7 +16,7 @@ cargo-subcommand = "0.4.6"
 dunce = "1.0"
 env_logger = "0.7.1"
 log = "0.4.8"
-ndk-build = { path = "../ndk-build", version = "0.1.2" }
+ndk-build = { path = "../ndk-build", version = "0.1.3" }
 serde = "1.0.104"
 thiserror = "1.0"
 toml = "0.5.6"

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -43,7 +43,7 @@ icon = "@mipmap/ic_launcher"
 # Defaults to false.
 fullscreen = false
 
-# Set the instruction of how the activity hsould be launched
+# Set the instruction of how the activity should be launched
 # See https://developer.android.com/guide/topics/manifest/activity-element#lmode
 # Defaults to standard.
 launch_mode = "standard"

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -43,6 +43,11 @@ icon = "@mipmap/ic_launcher"
 # Defaults to false.
 fullscreen = false
 
+# Set the instruction of how the activity hsould be launched
+# See https://developer.android.com/guide/topics/manifest/activity-element#lmode
+# Defaults to standard.
+launch_mode = "standard"
+
 # Set the minimum required OpenGL ES version.
 # Defaults to [3, 1]
 opengles_version = [3, 0]

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- `android:launchMode` is configurable.
+
 # 0.1.2 (2020-09-15)
 
 - `android:label` is configurable.

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.1.3 (2020-11-21)
+
 - `android:launchMode` is configurable.
 
 # 0.1.2 (2020-09-15)

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-build"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Utilities for building Android binaries"

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -67,6 +67,7 @@ impl ApkConfig {
             icon: metadata.icon,
             fullscreen: metadata.fullscreen.unwrap_or(false),
             orientation: metadata.orientation,
+            launch_mode: metadata.launch_mode,
             application_metadatas,
             activity_metadatas,
         };

--- a/ndk-build/src/config.rs
+++ b/ndk-build/src/config.rs
@@ -28,6 +28,7 @@ pub struct Metadata {
     pub icon: Option<String>,
     pub fullscreen: Option<bool>,
     pub orientation: Option<String>,
+    pub launch_mode: Option<String>,
     pub opengles_version: Option<(u8, u8)>,
     pub feature: Option<Vec<FeatureConfig>>,
     pub permission: Option<Vec<PermissionConfig>>,

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -19,6 +19,7 @@ pub struct Manifest {
     pub icon: Option<String>,
     pub fullscreen: bool,
     pub orientation: Option<String>,
+    pub launch_mode: Option<String>,
     pub debuggable: bool,
     pub split: Option<String>,
     pub application_metadatas: Vec<ApplicationMetadata>,
@@ -48,6 +49,7 @@ impl Manifest {
         };
 
         let orientation = self.orientation.as_deref().unwrap_or("unspecified");
+        let launch_mode = self.launch_mode.as_deref().unwrap_or("standard");
 
         let features: Vec<String> = self.features.iter().map(|f| f.to_string()).collect();
         let permissions: Vec<String> = self.permissions.iter().map(|p| p.to_string()).collect();
@@ -88,6 +90,7 @@ impl Manifest {
                 android:name="android.app.NativeActivity"
                 android:label="{package_label}"
                 android:screenOrientation="{orientation}"
+                android:launchMode="{launch_mode}"
                 android:configChanges="orientation|keyboardHidden|screenSize">
             <meta-data android:name="android.app.lib_name" android:value="{target_name}" />
             {activity_metadatas}
@@ -111,6 +114,7 @@ impl Manifest {
             icon = icon,
             fullscreen = fullscreen,
             orientation = orientation,
+            launch_mode = launch_mode,
             application_metadatas = application_metadatas.join("\n"),
             activity_metadatas = activity_metadatas.join("\n"),
             debuggable = self.debuggable,


### PR DESCRIPTION
Fixes #95 - although it would nice to introduce a proper serialize + deserialize mechanism for generating the `AndroidManifest.xml`

Would love to see this released in `cargo-apk` immediately after as it's a must feature for a project that I'm working on. Thanks in advance! :)

