### PR TITLE
Fixed UNC path handling on Windows for resource folder

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+# 0.5.6 (2020-11-25)
+
+- Use `dunce::simplified` when extracting the manifest's assets and resource folder
+- Updated to use [ndk-build 0.1.4](../ndk-build/CHANGELOG.md#012-2020-11-25)
+
 # 0.5.5 (2020-11-21)
 
 - Updated to use [ndk-build 0.1.3](../ndk-build/CHANGELOG.md#012-2020-11-21)

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -3,11 +3,11 @@
 # 0.5.6 (2020-11-25)
 
 - Use `dunce::simplified` when extracting the manifest's assets and resource folder
-- Updated to use [ndk-build 0.1.4](../ndk-build/CHANGELOG.md#012-2020-11-25)
+- Updated to use [ndk-build 0.1.4](../ndk-build/CHANGELOG.md#014-2020-11-25)
 
 # 0.5.5 (2020-11-21)
 
-- Updated to use [ndk-build 0.1.3](../ndk-build/CHANGELOG.md#012-2020-11-21)
+- Updated to use [ndk-build 0.1.3](../ndk-build/CHANGELOG.md#013-2020-11-21)
 
 # 0.5.4 (2020-11-01)
 

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-apk"
-version = "0.5.5"
+version = "0.5.6"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Helps cargo build APKs"
@@ -16,7 +16,7 @@ cargo-subcommand = "0.4.6"
 dunce = "1.0"
 env_logger = "0.7.1"
 log = "0.4.8"
-ndk-build = { path = "../ndk-build", version = "0.1.3" }
+ndk-build = { path = "../ndk-build", version = "0.1.4" }
 serde = "1.0.104"
 thiserror = "1.0"
 toml = "0.5.6"

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -66,21 +66,26 @@ impl<'a> ApkBuilder<'a> {
             target_name: artifact.name().replace("-", "_"),
             debuggable: *self.cmd.profile() == Profile::Dev,
             assets: self.manifest.assets.as_ref().map(|assets| {
-                self.cmd
-                    .manifest()
-                    .parent()
-                    .expect("invalid manifest path")
-                    .join(&assets)
+                dunce::simplified(
+                    &self
+                        .cmd
+                        .manifest()
+                        .parent()
+                        .expect("invalid manifest path")
+                        .join(&assets),
+                )
+                .to_owned()
             }),
             res: self.manifest.res.as_ref().map(|res| {
-                self.cmd
-                    .manifest()
-                    .parent()
-                    .expect("invalid manifest path")
-                    .join(&res)
-                    .to_str()
-                    .unwrap()
-                    .to_owned()
+                dunce::simplified(
+                    &self
+                        .cmd
+                        .manifest()
+                        .parent()
+                        .expect("invalid manifest path")
+                        .join(&res),
+                )
+                .to_owned()
             }),
         };
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 0.1.4 (2020-11-25)
 
-- Fixed UNC path handling on Windows for resource folder
+- On Windows, fixed UNC path handling for resource folder
 
 # 0.1.3 (2020-11-21)
 
@@ -17,7 +17,7 @@
 # 0.1.1 (2020-07-15)
 
 - Added support for custom intent filters.
-- Fixed UNC path handling on Windows.
+- On Windows, fixed UNC path handling.
 - Fixed toolchain path handling when the NDK installation has no host arch suffix on its prebuilt LLVM directories.
 
 # 0.1.0 (2020-04-22)

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.1.4 (2020-11-25)
+
+- Fixed UNC path handling on Windows for resource folder
+
 # 0.1.3 (2020-11-21)
 
 - `android:launchMode` is configurable.

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-build"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Utilities for building Android binaries"

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -10,7 +10,7 @@ pub struct ApkConfig {
     pub ndk: Ndk,
     pub build_dir: PathBuf,
     pub assets: Option<PathBuf>,
-    pub res: Option<String>,
+    pub res: Option<PathBuf>,
     pub manifest: Manifest,
 }
 
@@ -115,7 +115,7 @@ impl ApkConfig {
         }
 
         if let Some(assets) = &self.assets {
-            aapt.arg("-A").arg(dunce::simplified(assets));
+            aapt.arg("-A").arg(assets);
         }
 
         if !aapt.status()?.success() {

--- a/ndk-build/src/config.rs
+++ b/ndk-build/src/config.rs
@@ -17,7 +17,7 @@ pub struct Config {
     pub target_name: String,
     pub debuggable: bool,
     pub assets: Option<PathBuf>,
-    pub res: Option<String>,
+    pub res: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]


### PR DESCRIPTION
Small fix using `dunce::simplified` when extracting the manifest's assets and resource folder instead of only using it in  `aapt.arg(dunce::simplified(assets))`. Also bumped the versions as I would love to see this published. :) 