### PR TITLE
Update android_logger

### DIFF
--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -18,7 +18,7 @@ ndk-macro = { path = "../ndk-macro", version = "0.2.0" }
 lazy_static = "1.4.0"
 libc = "0.2.66"
 log = "0.4.8"
-android_logger = { version = "0.9.2", optional = true }
+android_logger = { version = "0.9", optional = true }
 
 [features]
 default = []

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -18,7 +18,7 @@ ndk-macro = { path = "../ndk-macro", version = "0.2.0" }
 lazy_static = "1.4.0"
 libc = "0.2.66"
 log = "0.4.8"
-android_logger = { version = "0.8.6", optional = true }
+android_logger = { version = "0.9.2", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
android_logger 0.8.6 depends on android_log-sys 0.1.2. As Bevy depends on both ndk-glue and android_log-sys 0.2, this will cause android_log-sys to be compiled twice. android_logger 0.9.2 however depends on android_log-sys 0.2, avoiding the duplicate dependency.