### PR TITLE
ndk,ndk-glue: Do not pass Looper ident as userdata pointer

### DIFF
--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+- **Breaking** Looper `ident` not passed in `data` pointer anymore.
+  If you are relying on `Poll::Event::data` to tell event fd and
+  input queue apart, please use `Poll::Event::ident` and the new
+  constants introduced in `ndk-glue`!
+
 # 0.2.1 (2020-10-15)
 
 - Fix documentation build on docs.rs

--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.3.0 (2021-01-30)
+
 - **Breaking** Looper `ident` not passed in `data` pointer anymore.
   If you are relying on `Poll::Event::data` to tell event fd and
   input queue apart, please use `Poll::Event::ident` and the new

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-glue"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Startup code for android binaries"
@@ -12,7 +12,7 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
-ndk = { path = "../ndk", version = "0.2.1" }
+ndk = { path = "../ndk", version = "0.3.0" }
 ndk-sys = { path = "../ndk-sys", version = "0.2.1" }
 ndk-macro = { path = "../ndk-macro", version = "0.2.0" }
 lazy_static = "1.4.0"

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+- **Breaking** Looper `ident` not passed in `data` pointer anymore.
+  `attach_looper` now only sets the `ident` field when attaching an
+  `InputQueue` to a `ForeignLooper`.
+  If you are relying on `Poll::Event::data` to tell event fd and
+  input queue apart, please use `Poll::Event::ident` and the new
+  constants introduced in `ndk-glue`!
+
 # 0.2.1 (2020-10-15)
 
 - Fix documentation build on docs.rs

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.3.0 (2021-01-30)
+
 - **Breaking** Looper `ident` not passed in `data` pointer anymore.
   `attach_looper` now only sets the `ident` field when attaching an
   `InputQueue` to a `ForeignLooper`.

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Safe Rust bindings to the Android NDK"

--- a/ndk/src/input_queue.rs
+++ b/ndk/src/input_queue.rs
@@ -71,14 +71,14 @@ impl InputQueue {
         }
     }
 
-    pub fn attach_looper(&self, looper: &ForeignLooper, id: u32) {
+    pub fn attach_looper(&self, looper: &ForeignLooper, id: i32) {
         unsafe {
             ffi::AInputQueue_attachLooper(
                 self.ptr.as_ptr(),
                 looper.ptr().as_ptr(),
-                id as _,
+                id,
                 None,
-                id as _,
+                std::ptr::null_mut(),
             );
         }
     }


### PR DESCRIPTION
The value of `0` or `1` is not a valid pointer to a userdata structure.  Not that it has to be, but with the nasty consequence that winit Android code was accidentally reinterpreting this pointer as integer to extract the identifier from, instead of using the appropriate `ident` field directly. After that is addressed in winit we can set the pointer back to 0 cleanly (and prepare for a potential pointer to some user data that may be passed in the future).

Also add some constants to document these "special" identifiers.

---

Maintainers, this is a breaking change in `ndk-glue` that we want to bump our minor version for, to v0.3. Anyone upgrading now will always see `null()` in the `data` field, wrecking `winit` unless https://github.com/rust-windowing/winit/pull/1826 is in, which will only land in 0.25.

After releasing this we should do a small patch to `winit` to use the new v0.3 crate together with the new constants for clarity.

CC @nwessing: the extra bit of documentation in here might help your adventure into using the glue crate directly!