### PR TITLE
Remove Windows NDK symlink and run apk check + build in separate steps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,10 +94,11 @@ jobs:
         echo "ANDROID_NDK_HOME=" >> $env:GITHUB_ENV
         echo "ANDROID_NDK_PATH=" >> $env:GITHUB_ENV
 
-    - name: Check compiling on target ${{ matrix.rust-target }}
-      run: |
-        cargo check -p ndk --target ${{ matrix.rust-target }} --all-features
-        cargo apk build -p ndk-examples --target ${{ matrix.rust-target }} --examples
+    - name: Cargo check for target ${{ matrix.rust-target }}
+      run: cargo check -p ndk --target ${{ matrix.rust-target }} --all-features
+
+    - name: Cargo apk build for target ${{ matrix.rust-target }}
+      run: cargo apk build -p ndk-examples --target ${{ matrix.rust-target }} --examples
 
     - name: Check NDK docs for ${{ matrix.rust-target }}
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,23 +77,6 @@ jobs:
       run:
         cargo install --path cargo-apk
 
-    - if: runner.os == 'Windows'
-      name: Create symlink to Android SDK/NDK without spaces
-      run: |
-        $oldAndroidPath = $env:ANDROID_HOME
-        $sdk_root = "C:\Android"
-        New-Item -Path $sdk_root -ItemType SymbolicLink -Value $oldAndroidPath
-
-        echo "ANDROID_SDK_ROOT=$sdk_root" >> $env:GITHUB_ENV
-        echo "ANDROID_NDK_ROOT=$sdk_root\ndk-bundle" >> $env:GITHUB_ENV
-
-        # Update legacy path for ndk-build:
-        echo "ANDROID_HOME=$sdk_root" >> $env:GITHUB_ENV
-
-        # Unset legacy paths:
-        echo "ANDROID_NDK_HOME=" >> $env:GITHUB_ENV
-        echo "ANDROID_NDK_PATH=" >> $env:GITHUB_ENV
-
     - name: Cargo check for target ${{ matrix.rust-target }}
       run: cargo check -p ndk --target ${{ matrix.rust-target }} --all-features
 


### PR DESCRIPTION
An obscure one-line `apk build` failure got shadowed by a much larger deprecation warning shown by `cargo check` right above, deemed irrelevant. Separating these steps will make it clear when the issue is code-related (ndk, ndk-glue) or build-related (ndk-build, cargo-apk, cargo-subcommand).

---

GH actions virtual environments have finally been fixed to provide a space-less path to the SDK and NDK by default :tada:. The workaround - introduced in #92 - can finally be removed again!