### PR TITLE
Rework Event type to allow synchronized cleanup

### DIFF
--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.4.0"
 libc = "0.2.84"
 log = "0.4.14"
 android_logger = { version = "0.9.2", optional = true }
+crossbeam-queue = "0.3"
 
 [features]
 default = []

--- a/ndk/src/looper.rs
+++ b/ndk/src/looper.rs
@@ -262,4 +262,16 @@ impl ForeignLooper {
             _ => unreachable!(),
         }
     }
+
+    pub unsafe fn remove_fd(
+        &self,
+        fd: RawFd
+    ) -> Result<bool, LooperError> {
+        match ffi::ALooper_removeFd(self.ptr.as_ptr(), fd) {
+            1 => Ok(true),
+            0 => Ok(false),
+            -1 => Err(LooperError),
+            _ => unreachable!(),
+        }
+    }
 }


### PR DESCRIPTION
Previously, `NativeActivity` callbacks returned immediately after dispatching an asynchronous `Event` to the user on a UNIX pipe. This made it impossible to handle destruction callbacks (`on_native_window_destroyed`, `on_input_queue_destroyed`) in a manner conforming with the Android docs, which state that all cleanup must be completed *before* the callback returns, cf. [`ANativeActivityCallbacks docs`](https://developer.android.com/ndk/reference/struct/a-native-activity-callbacks#struct_a_native_activity_callbacks_1a6aaafbbfae4c0ac066b9d61ebb3ab97f).

Therefore, some method of blocking and then notifying the callback had to be introduced. In order to accomplish this, I wrote a simple wrapper on a lockless queue (`crossbeam_queue::SegQueue`) and an `eventfd` object, which allows sending arbitrary Rust objects to the user while notifying the Android `Looper` in a manner preserving the source of the notification.

This enabled a different semantics of the `Event` type. `Events` now transfer ownership of various Android handles (e.g. `NativeActivity`, `InputQueue`) to the user. The user is responsible for hanging on to these handles. When a corresponding `*Destroyed` event is received, the user must ensure that they complete all cleanup before dropping the contained `EventSyncGuard` object. They must not touch the relevant handle afterwards.

Additionally, care is taken to prevent the user from obtaining a handle to a `NativeWindow` or an `InputQueue` after a corresponding `*_destroyed` callback has fired. In this case, the `*Created` event will deliver `None` and no corresponding `*Destroyed` event will be dispatched.

This is a somewhat significant change of the public API and there are ways to make it more similar to the current version or just more ergonomic. I'm open to discussing these, as well as any performance or synchronization concerns.