### PR TITLE
ci: Check all crate documentation in addition to target-specific ndk

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,13 @@ jobs:
       run:
         cargo test -p cargo-apk --all-features
 
+    - if: runner.os != 'Windows'
+      name: Document all crates
+      env:
+        RUSTDOCFLAGS: -Dwarnings
+      run:
+        cargo doc --all --all-features
+
     - name: Install cargo-apk
       run:
         cargo install --path cargo-apk

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,9 +89,3 @@ jobs:
 
     - name: Cargo apk build for target ${{ matrix.rust-target }}
       run: cargo apk build -p ndk-examples --target ${{ matrix.rust-target }} --examples
-
-    - name: Check NDK docs for ${{ matrix.rust-target }}
-      env:
-        RUSTDOCFLAGS: -Dwarnings
-      run:
-        cargo doc -p ndk --target ${{ matrix.rust-target }} --all-features


### PR DESCRIPTION
Following https://github.com/rust-windowing/android-ndk-rs/pull/106#pullrequestreview-565655645

Only `ndk` docs are built for all `android` targets but the rest of the documentation remains untested. Especially now that we're expanding to provide more complete docs for ndk-build and cargo-apk should everything be tested, to make sure that things like intra-doc links remain in working order.

## TODO

The `ndk` docs build successfully here thanks to the `test` feature (enabled by `--all-features`); does it still make a lot of sense to build-test the documentation for every target individually?