### PR TITLE
ci: Run target-agnostic build/test steps only once 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,7 @@ jobs:
             rust-target: 'aarch64-linux-android'
 
     runs-on: ${{ matrix.os }}
+    name: Build apk
 
     steps:
     - uses: actions/checkout@v2
@@ -45,41 +46,6 @@ jobs:
         target: ${{ matrix.rust-target }}
         override: true
 
-    - if: runner.os != 'Windows'
-      name: Test ndk-sys
-      run:
-        cargo test -p ndk-sys --all-features
-
-    - if: runner.os != 'Windows'
-      name: Test ndk
-      run:
-        cargo test -p ndk --all-features
-
-    - name: Test ndk-build
-      run:
-        cargo test -p ndk-build --all-features
-
-    - if: runner.os != 'Windows'
-      name: Test ndk-glue
-      run:
-        cargo test -p ndk-glue --all-features
-
-    - if: runner.os != 'Windows'
-      name: Test ndk-macro
-      run:
-        cargo test -p ndk-macro --all-features
-
-    - name: Test cargo-apk
-      run:
-        cargo test -p cargo-apk --all-features
-
-    - if: runner.os != 'Windows'
-      name: Document all crates
-      env:
-        RUSTDOCFLAGS: -Dwarnings
-      run:
-        cargo doc --all --all-features
-
     - name: Install cargo-apk
       run:
         cargo install --path cargo-apk
@@ -89,3 +55,52 @@ jobs:
 
     - name: Cargo apk build for target ${{ matrix.rust-target }}
       run: cargo apk build -p ndk-examples --target ${{ matrix.rust-target }} --examples
+
+  build-host:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:  [ubuntu-latest]
+        rust-channel: ['stable', 'nightly']
+
+    runs-on: ${{ matrix.os }}
+    name: Host-side tests and docs
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Installing Rust ${{ matrix.rust-channel }}
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust-channel }}
+        override: true
+
+    - name: Test ndk-sys
+      run:
+        cargo test -p ndk-sys --all-features
+
+    - name: Test ndk
+      run:
+        cargo test -p ndk --all-features
+
+    - name: Test ndk-build
+      run:
+        cargo test -p ndk-build --all-features
+
+    - name: Test ndk-glue
+      run:
+        cargo test -p ndk-glue --all-features
+
+    - name: Test ndk-macro
+      run:
+        cargo test -p ndk-macro --all-features
+
+    - name: Test cargo-apk
+      run:
+        cargo test -p cargo-apk --all-features
+
+    - name: Document all crates
+      env:
+        RUSTDOCFLAGS: -Dwarnings
+      run:
+        cargo doc --all --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,7 @@ jobs:
         rust-channel: ['stable', 'nightly']
 
     runs-on: ${{ matrix.os }}
-    name: Host-side tests and docs
+    name: Host-side tests
 
     steps:
     - uses: actions/checkout@v2
@@ -98,6 +98,25 @@ jobs:
     - name: Test cargo-apk
       run:
         cargo test -p cargo-apk --all-features
+
+  docs:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:  [ubuntu-latest]
+        rust-channel: ['stable', 'nightly']
+
+    runs-on: ${{ matrix.os }}
+    name: Build-test docs
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Installing Rust ${{ matrix.rust-channel }}
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust-channel }}
+        override: true
 
     - name: Document all crates
       env:


### PR DESCRIPTION
From https://github.com/rust-windowing/android-ndk-rs/pull/129#issuecomment-803299047

A lot of these steps - except apk building - are not target-specific (do not have a `--target` option; `target:` on `actions-rs/toolchain` only specifies what targets to install). This is a waste of time despite all duplication running in parallel, and could be used to run a target-specific apk build in parallel with host-side tests instead.

It should be fine to perform just the apk build step on Windows, and leave the rest (tests, documentation) to Linux runners only - most of those steps were not ran on Windows anyway.

This takes CI time down from 6m30s to just under 5m, with around 3m spent in apk building (in parallel), 3m40s spent testing all cates and docs on the host, and under 5m for apk building on Windows (defining the baseline for total build completion time).

---

EDIT: With the second commit separating (hence parallelizing) host-tests from documentation build-testing, these steps are now down to 2m40 resp 2min. Not that it matters, the Windows test defines our lower bound :rage: 