### PR TITLE
Notify event pipe before releasing NativeActivity resources

### DIFF
--- a/ndk-glue/src/lib.rs
+++ b/ndk-glue/src/lib.rs
@@ -260,8 +260,8 @@ unsafe extern "C" fn on_window_destroyed(
     activity: *mut ANativeActivity,
     _window: *mut ANativeWindow,
 ) {
-    *NATIVE_WINDOW.write().unwrap() = None;
     wake(activity, Event::WindowDestroyed);
+    *NATIVE_WINDOW.write().unwrap() = None;
 }
 
 unsafe extern "C" fn on_input_queue_created(
@@ -279,10 +279,12 @@ unsafe extern "C" fn on_input_queue_destroyed(
     activity: *mut ANativeActivity,
     queue: *mut AInputQueue,
 ) {
+    wake(activity, Event::InputQueueDestroyed);
+    let mut input_queue_guard = INPUT_QUEUE.write().unwrap();
+    assert_eq!(input_queue_guard.as_ref().unwrap().ptr().as_ptr(), queue);
     let input_queue = InputQueue::from_ptr(NonNull::new(queue).unwrap());
     input_queue.detach_looper();
-    *INPUT_QUEUE.write().unwrap() = None;
-    wake(activity, Event::InputQueueDestroyed);
+    *input_queue_guard = None;
 }
 
 unsafe extern "C" fn on_content_rect_changed(activity: *mut ANativeActivity, rect: *const ARect) {


### PR DESCRIPTION
Currently, some `NativeActivity` callbacks (`on_native_window_destroyed`, `on_input_queue_destroyed`):
(1) acquire a write lock on a static handle to the resource that is about to be destroyed, (2) drop the handle, (3) dispatch an asynchronous `Event` to the user on a UNIX pipe notifying of the release, (4) immediately return from the callback.

This is incorrect according to [`ANativeActivityCallbacks docs`](https://developer.android.com/ndk/reference/struct/a-native-activity-callbacks#struct_a_native_activity_callbacks_1a6aaafbbfae4c0ac066b9d61ebb3ab97f). If the user is holding on to a read lock on the handle (as they should), there will be a deadlock. If the user does not have a read lock on the handle, there is a race condition, since Android may free the resource before the user cleans up all the objects derived from that resource (e.g. `EGLSurface` from `NativeWindow`).

In order to prevent races, `ndk_glue` should (1) notify users of upcoming resource release, so they can correctly clean up derived objects, and only then (2) acquire a write lock on the handle, (3) drop the handle, (4) return from the callback.

Closes #117 