### PR TITLE
ndk-build: Use LLVM binutils when GNU binutils are removed (r23+)

### DIFF
--- a/ndk-build/src/error.rs
+++ b/ndk-build/src/error.rs
@@ -23,24 +23,24 @@ pub enum NdkError {
         gnu_bin: String,
         llvm_bin: String,
     },
-    #[error("Path {0:?} doesn't exist.")]
+    #[error("Path `{0:?}` doesn't exist.")]
     PathNotFound(PathBuf),
-    #[error("Command {0} not found.")]
+    #[error("Command `{0}` not found.")]
     CmdNotFound(String),
     #[error("Android SDK has no build tools.")]
     BuildToolsNotFound,
     #[error("Android SDK has no platforms installed.")]
     NoPlatformFound,
-    #[error("Platform {0} is not installed.")]
+    #[error("Platform `{0}` is not installed.")]
     PlatformNotFound(u32),
     #[error("Target is not supported.")]
     UnsupportedTarget,
-    #[error("Host {0} is not supported.")]
+    #[error("Host `{0}` is not supported.")]
     UnsupportedHost(String),
     #[error(transparent)]
     Io(#[from] IoError),
     #[error("Invalid semver")]
     InvalidSemver,
-    #[error("Command '{}' had a non-zero exit code.", format!("{:?}", .0).replace('"', ""))]
+    #[error("Command `{}` had a non-zero exit code.", format!("{:?}", .0).replace('"', ""))]
     CmdFailed(Command),
 }

--- a/ndk-build/src/error.rs
+++ b/ndk-build/src/error.rs
@@ -17,6 +17,12 @@ pub enum NdkError {
         environment variable."
     )]
     NdkNotFound,
+    #[error("GNU toolchain binary `{gnu_bin}` nor LLVM toolchain binary `{llvm_bin}` found in `{toolchain_path:?}`.")]
+    ToolchainBinaryNotFound {
+        toolchain_path: PathBuf,
+        gnu_bin: String,
+        llvm_bin: String,
+    },
     #[error("Path {0:?} doesn't exist.")]
     PathNotFound(PathBuf),
     #[error("Command {0} not found.")]


### PR DESCRIPTION
Since [r21] LLVM binutils are included _for testing_;
Since [r22] GNU binutils are deprecated in favour of LLVM's;
Since [r23] GNU binutils have been removed.

When GNU binutils are not available (`<triple>-<bin_name>`) "fall back" to `llvm-<bin_name>` binaries from LLVM binutils that are now included with the NDK.

To maintain stability with the current ndk-build crate release, prefer GNU binutils for as long as it is provided by the NDK instead of trying to use `llvm-<bin_name>` from r21 onwards.

[r21]: https://github.com/android/ndk/wiki/Changelog-r21
[r22]: https://github.com/android/ndk/wiki/Changelog-r22
[r23]: https://github.com/android/ndk/wiki/Changelog-r23

Fixes #135

---

We could also opt for LLVM binutils in r22 (requires extra logic to figure out whether we're building on r21 or r22) where GNU binutils are technically deprecated, but since the current crate release already uses that successfully there seems no need to change it at risk of breaking projects that are somehow incompatible.