### PR TITLE
Allow adding additional libraries to APK

### DIFF
--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -101,6 +101,10 @@ value = "vr_only"
 [[package.metadata.android.activity_metadatas]]
 name = "com.oculus.vr.focusaware"
 value = "true"
+
+# Bundles additional shared object libraries into the APK.
+# Note that this is not required if Rust already links against this object.
+libs = [ "path/to/lib.so" ]
 ```
 
 TODO: intent filters

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -8,6 +8,7 @@ use ndk_build::dylibs::get_libs_search_paths;
 use ndk_build::error::NdkError;
 use ndk_build::ndk::Ndk;
 use ndk_build::target::Target;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -123,6 +124,14 @@ impl<'a> ApkBuilder<'a> {
                 .collect::<Vec<_>>();
 
             apk.add_lib_recursively(&artifact, *target, libs_search_paths.as_slice())?;
+
+            if let Some(libs) = &self.manifest.metadata.libs {
+                let empty = Vec::new();
+                for lib in libs {
+                    let lib_path = Path::new(lib);
+                    apk.add_lib_recursively(&lib_path, *target, &empty)?;
+                }
+            }
         }
 
         Ok(apk.align()?.sign(config.ndk.debug_key()?)?)

--- a/ndk-build/src/config.rs
+++ b/ndk-build/src/config.rs
@@ -35,6 +35,7 @@ pub struct Metadata {
     pub intent_filter: Option<Vec<IntentFilterConfig>>,
     pub application_metadatas: Option<Vec<ApplicationMetadataConfig>>,
     pub activity_metadatas: Option<Vec<ActivityMetadataConfig>>,
+    pub libs: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
This change adds the additional `libs` parameter to `package.metadata.android`.

I added this so specifically address edge cases where my final library did not link against a particular object, but it was still required at run-time - eg. vulkan validation layers.

I tried to go with the "most obvious" approach, but if you have something else in mind, please just let me know. I tested this with my Android device and it seemed to work quite well.

I've added some simple documentation to `README.md` but if you need anything further, I'd be happy to add it.