### PR TITLE
Add support for android string resource id in application label. (#145)

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.6.0 (2021-05-06)
+# Unreleased (2021-05-06)
 
 - Added support for android string resource id in application label.
 - Added `apk_name` field to android metadata for APK file naming (fall back to artifact name).

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,7 +1,7 @@
-# Unreleased (2021-05-06)
+# Unreleased
 
-- Added support for android string resource id in application label.
-- Added `apk_name` field to android metadata for APK file naming (fall back to artifact name).
+- Added `apk_name` field to android metadata for APK file naming (defaults to Rust library name if unspecified).
+  The application label is now no longer used for this purpose, and can contain a string resource ID from now on.
 
 # 0.6.0 (2021-04-20)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.6.0 (2021-05-06)
+
+- Added support for android string resource id in application label.
+- Added `apk_name` field to android metadata for APK file naming (fall back to artifact name).
+
 # 0.6.0 (2021-04-20)
 
 - **Breaking:** uses `ndk-build`'s new (de)serialized `Manifest` struct to properly serialize a toml's `[package.metadata.android]` to an `AndroidManifest.xml`. The `[package.metadata.android]` now closely resembles the structure of [an android manifest file](https://developer.android.com/guide/topics/manifest/manifest-element). See [README](README.md) for an example of the new `[package.metadata.android]` structure and all manifest attributes that are currently supported.

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -38,6 +38,10 @@ resources = "path/to/resources_folder"
 # If not specified, assets will not be included in the APK.
 assets = "path/to/assets_folder"
 
+# Name for final APK file.
+# Defaults to package name.
+apk_name = "myapp"
+
 # See https://developer.android.com/guide/topics/manifest/uses-sdk-element
 #
 # Defaults to a `min_sdk_version` of 23 and `target_sdk_version` is based on the ndk's default platform.

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -98,9 +98,6 @@ impl<'a> ApkBuilder<'a> {
         if manifest.application.label.is_empty() {
             manifest.application.label = artifact.name().to_string();
         }
-        if manifest.application.name.is_empty() {
-            manifest.application.name = artifact.name().to_string();
-        }
 
         let assets = self.manifest.assets.as_ref().map(|assets| {
             dunce::simplified(
@@ -111,7 +108,7 @@ impl<'a> ApkBuilder<'a> {
                     .expect("invalid manifest path")
                     .join(&assets),
             )
-            .to_owned()
+                .to_owned()
         });
         let resources = self.manifest.resources.as_ref().map(|res| {
             dunce::simplified(
@@ -122,12 +119,16 @@ impl<'a> ApkBuilder<'a> {
                     .expect("invalid manifest path")
                     .join(&res),
             )
-            .to_owned()
+                .to_owned()
+        });
+        let apk_name = self.manifest.apk_name.clone().unwrap_or_else(|| {
+            artifact.name().to_string()
         });
 
         let config = ApkConfig {
             ndk: self.ndk.clone(),
             build_dir: self.build_dir.join(artifact),
+            apk_name,
             assets,
             resources,
             manifest,

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -98,6 +98,9 @@ impl<'a> ApkBuilder<'a> {
         if manifest.application.label.is_empty() {
             manifest.application.label = artifact.name().to_string();
         }
+        if manifest.application.name.is_empty() {
+            manifest.application.name = artifact.name().to_string();
+        }
 
         let assets = self.manifest.assets.as_ref().map(|assets| {
             dunce::simplified(

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -108,7 +108,7 @@ impl<'a> ApkBuilder<'a> {
                     .expect("invalid manifest path")
                     .join(&assets),
             )
-                .to_owned()
+            .to_owned()
         });
         let resources = self.manifest.resources.as_ref().map(|res| {
             dunce::simplified(
@@ -119,11 +119,13 @@ impl<'a> ApkBuilder<'a> {
                     .expect("invalid manifest path")
                     .join(&res),
             )
-                .to_owned()
+            .to_owned()
         });
-        let apk_name = self.manifest.apk_name.clone().unwrap_or_else(|| {
-            artifact.name().to_string()
-        });
+        let apk_name = self
+            .manifest
+            .apk_name
+            .clone()
+            .unwrap_or_else(|| artifact.name().to_string());
 
         let config = ApkConfig {
             ndk: self.ndk.clone(),

--- a/cargo-apk/src/manifest.rs
+++ b/cargo-apk/src/manifest.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 pub struct Manifest {
     pub version: String,
+    pub apk_name: Option<String>,
     pub android_manifest: AndroidManifest,
     pub build_targets: Vec<Target>,
     pub assets: Option<String>,
@@ -24,6 +25,7 @@ impl Manifest {
             .unwrap_or_default();
         Ok(Self {
             version: toml.package.version,
+            apk_name: metadata.apk_name,
             android_manifest: metadata.android_manifest,
             build_targets: metadata.build_targets,
             assets: metadata.assets,
@@ -50,6 +52,7 @@ struct PackageMetadata {
 
 #[derive(Clone, Debug, Default, Deserialize)]
 struct AndroidMetadata {
+    apk_name: Option<String>,
     #[serde(flatten)]
     android_manifest: AndroidManifest,
     #[serde(default)]

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0 (2021-05-06)
+
+- New `ApkConfig` field `apk_name` is now used for APK file naming.
+
 # 0.2.0 (2021-04-20)
 
 - **Breaking:** refactored `Manifest` into a proper (de)serialization struct. `Manifest` now closely matches [`an android manifest file`](https://developer.android.com/guide/topics/manifest/manifest-element).

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,7 +1,6 @@
-# Unreleased (2021-05-06)
+# Unreleased
 
-- New `ApkConfig` field `apk_name` is now used for APK file naming.
-- Application label is no longer used as APK file name.
+- New `ApkConfig` field `apk_name` is now used for APK file naming, instead of the application label.
 
 # 0.2.0 (2021-04-20)
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 0.2.0 (2021-05-06)
+# Unreleased (2021-05-06)
 
 - New `ApkConfig` field `apk_name` is now used for APK file naming.
+- Application label is no longer used as APK file name.
 
 # 0.2.0 (2021-04-20)
 

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -8,6 +8,7 @@ use std::process::Command;
 pub struct ApkConfig {
     pub ndk: Ndk,
     pub build_dir: PathBuf,
+    pub apk_name: String,
     pub assets: Option<PathBuf>,
     pub resources: Option<PathBuf>,
     pub manifest: AndroidManifest,
@@ -22,12 +23,12 @@ impl ApkConfig {
 
     fn unaligned_apk(&self) -> PathBuf {
         self.build_dir
-            .join(format!("{}-unaligned.apk", self.manifest.application.name))
+            .join(format!("{}-unaligned.apk", self.apk_name))
     }
 
     fn apk(&self) -> PathBuf {
         self.build_dir
-            .join(format!("{}.apk", self.manifest.application.name))
+            .join(format!("{}.apk", self.apk_name))
     }
 
     pub fn create_apk(&self) -> Result<UnalignedApk, NdkError> {

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -22,12 +22,12 @@ impl ApkConfig {
 
     fn unaligned_apk(&self) -> PathBuf {
         self.build_dir
-            .join(format!("{}-unaligned.apk", self.manifest.application.label))
+            .join(format!("{}-unaligned.apk", self.manifest.application.name))
     }
 
     fn apk(&self) -> PathBuf {
         self.build_dir
-            .join(format!("{}.apk", self.manifest.application.label))
+            .join(format!("{}.apk", self.manifest.application.name))
     }
 
     pub fn create_apk(&self) -> Result<UnalignedApk, NdkError> {

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -27,8 +27,7 @@ impl ApkConfig {
     }
 
     fn apk(&self) -> PathBuf {
-        self.build_dir
-            .join(format!("{}.apk", self.apk_name))
+        self.build_dir.join(format!("{}.apk", self.apk_name))
     }
 
     pub fn create_apk(&self) -> Result<UnalignedApk, NdkError> {

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -70,6 +70,9 @@ pub struct Application {
     #[serde(rename(serialize = "android:label"))]
     #[serde(default)]
     pub label: String,
+    #[serde(rename(serialize = "android:name"))]
+    #[serde(default)]
+    pub name: String,
 
     #[serde(rename(serialize = "meta-data"))]
     #[serde(default)]

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -70,9 +70,6 @@ pub struct Application {
     #[serde(rename(serialize = "android:label"))]
     #[serde(default)]
     pub label: String,
-    #[serde(rename(serialize = "android:name"))]
-    #[serde(default)]
-    pub name: String,
 
     #[serde(rename(serialize = "meta-data"))]
     #[serde(default)]


### PR DESCRIPTION
Fixes #145

Application label was used for apk file naming. Unfortunately, it lacks use of string resource id in application label. Application name (i.e. `applicaiton:name` tag in `AndroidManifest.xml`) is more appropriate for apk naming.