### PR TITLE
looper: Model `ALOOPER_EVENT` with `bitflags`

### DIFF
--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Reexport `android_logger` and `log` from the crate root for `ndk-macro` to use.
+- Use new `FdEvents` `bitflags` for looper file descriptor events.
 
 # 0.3.0 (2021-01-30)
 

--- a/ndk-glue/src/lib.rs
+++ b/ndk-glue/src/lib.rs
@@ -1,10 +1,10 @@
 use lazy_static::lazy_static;
 use log::Level;
 use ndk::input_queue::InputQueue;
-use ndk::looper::{ForeignLooper, ThreadLooper};
+use ndk::looper::{FdEvent, ForeignLooper, ThreadLooper};
 use ndk::native_activity::NativeActivity;
 use ndk::native_window::NativeWindow;
-use ndk_sys::{AInputQueue, ANativeActivity, ANativeWindow, ARect, ALOOPER_EVENT_INPUT};
+use ndk_sys::{AInputQueue, ANativeActivity, ANativeWindow, ARect};
 use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -187,7 +187,7 @@ pub unsafe fn init(
             .add_fd(
                 PIPE[0],
                 NDK_GLUE_LOOPER_EVENT_PIPE_IDENT,
-                ALOOPER_EVENT_INPUT as _,
+                FdEvent::INPUT,
                 std::ptr::null_mut(),
             )
             .unwrap();

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **Breaking** Model looper file descriptor events integer as `bitflags`.
+
 # 0.3.0 (2021-01-30)
 
 - **Breaking** Looper `ident` not passed in `data` pointer anymore.

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -32,8 +32,9 @@ api-level-30 = ["api-level-29"]
 test = ["ffi/test", "jni", "jni-glue", "all"]
 
 [dependencies]
-num_enum = "0.5.1"
+bitflags = "1.2.1"
 jni-sys = "0.3.0"
+num_enum = "0.5.1"
 thiserror = "1.0.23"
 
 [dependencies.jni]


### PR DESCRIPTION
The `event` field/parameter cannot have more states than these few carefully defined constants, and should be exposed as a proper restricted type since it's part of the public API.