### PR TITLE
ndk-macro: Update proc-macro-crate to 1.0, update darling to 0.13

### DIFF
--- a/ndk-macro/Cargo.toml
+++ b/ndk-macro/Cargo.toml
@@ -16,10 +16,10 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0.24"
-proc-macro-crate = "0.1.5"
+proc-macro-crate = "1.0"
 quote = "1.0.8"
 syn = { version = "1.0.60", features = ["full"] }
-darling = "0.12.0"
+darling = "0.13"
 
 [features]
 default = []


### PR DESCRIPTION
Depends on #162 

proc-macro-crate 1.0 released, and [num_enum] bumped to that recently in a patch release causing a duplicate dependency in `Cargo.lock`.  We can upgrade to it too.
    
[num_enum]: https://github.com/illicitonion/num_enum/commit/8385dc995b6a796b02e072f02e9019f15b334791