### PR TITLE
ndk-glue: Add missing entries to changelog and perform patch release 0.3.1

### DIFF
--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+- Looper is now created before returning from `ANativeActivity_onCreate`, solving
+  race conditions in `onInputQueueCreated`.
+- Event pipe and looper are now notified of removal _before_ destroying `NativeWindow`
+  and `InputQueue`. This allows applications to unlock their read-locks of these instances
+  first (which they are supposed to hold on to during use) instead of deadlocking in
+  Android callbacks.
 - Reexport `android_logger` and `log` from the crate root for `ndk-macro` to use.
 - Use new `FdEvents` `bitflags` for looper file descriptor events.
 

--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.3.1 (2021-07-29)
+
 - Looper is now created before returning from `ANativeActivity_onCreate`, solving
   race conditions in `onInputQueueCreated`.
 - Event pipe and looper are now notified of removal _before_ destroying `NativeWindow`

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-glue"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Startup code for android binaries"


### PR DESCRIPTION
Fixes #164 

It seems these threading fixes went unnoticed for a while as they didn't have anything added to `CHANGELOG.md`. Still, they're both vital in preventing deadlocks and race-conditions.

I don't think any of these are breaking and warrant a minor release, so a patch should be fine to get it in everyones hands smoothly, before the next breaking changes (see open PRs) land.