### PR TITLE
Release ndk 0.4.0, ndk-glue 0.4.0, ndk-build 0.4.1

### DIFF
--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.4.1 (2021-08-02)
+
+- Only the highest platform supported by the NDK is now selected as default platform.
+
 # 0.4.0 (2021-07-06)
 
 - Added `add_runtime_libs` function for including extra dynamic libraries in the APK.

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-build"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Utilities for building Android binaries"

--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.3.1 (2021-07-29)
+# 0.4.0 (2021-08-02)
 
 - Looper is now created before returning from `ANativeActivity_onCreate`, solving
   race conditions in `onInputQueueCreated`.
@@ -10,6 +10,8 @@
   Android callbacks.
 - Reexport `android_logger` and `log` from the crate root for `ndk-macro` to use.
 - Use new `FdEvents` `bitflags` for looper file descriptor events.
+- Update to `ndk` 0.4.0.
+  This minor dependency bump causes a minor bump for `ndk-glue` too.
 
 # 0.3.0 (2021-01-30)
 

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-glue"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Startup code for android binaries"
@@ -12,7 +12,7 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
-ndk = { path = "../ndk", version = "0.3.0" }
+ndk = { path = "../ndk", version = "0.4.0" }
 ndk-sys = { path = "../ndk-sys", version = "0.2.1" }
 ndk-macro = { path = "../ndk-macro", version = "0.2.0" }
 lazy_static = "1.4.0"

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.4.0 (2021-08-02)
+
 - **Breaking** Model looper file descriptor events integer as `bitflags`.
 
 # 0.3.0 (2021-01-30)

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Safe Rust bindings to the Android NDK"


### PR DESCRIPTION
Fixes #164

~ndk-glue 0.3.1 depends on a breaking change in the NDK, and can only be released if that's released under 0.4.0.~

---

~Draft: I'm not sure if this is the right thing to do, or if we should aim for ndk-glue `0.4.0`. ndk-glue exposes quite a few NDK symbols in its public API, and running `cargo update` in a crate that uses both (very likely) they'll end up with duplicate crates and incompatible types unless they manually update to ndk 0.4 (which is possibly, but unexpected sudden breakage because semver allows going from 0.3.0 to 0.3.1 without issues).~

---

ndk-glue depends on a breaking change in the NDK, and can only be released if that's released under 0.4.0.  This, in turn, causes ndk-glue to need a minor bump too despite no other breaking changes, as NDK symbols are used in its public API.

Note that ndk-glue 0.3.1 was never properly released as the ndk update requirement outlined above caused an adequate publishing failure.
