### PR TITLE
ndk-build: fix native activity library path on non-UNIX systems

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix NativeActivity library path on non-UNIX systems, which resulted in runtime crashes on startup.
+
 # 0.8.0 (2021-07-06)
 
 - Added `runtime_libs` path to android metadata for packaging extra dynamic libraries into the apk.

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Fix NativeActivity library path on non-UNIX systems, which resulted in runtime crashes on startup.
+- Pass UNIX path separators to `aapt` on non-UNIX systems, ensuring the resulting separator is compatible with the target device instead of the host platform.
 
 # 0.8.0 (2021-07-06)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased
 
-# 0.8.1 (2021-08-05)
+# 0.8.1 (2021-08-06)
 
-- Updated to use [ndk-build 0.4.2](../ndk-build/CHANGELOG.md#042-2021-08-05)
+- Updated to use [ndk-build 0.4.2](../ndk-build/CHANGELOG.md#042-2021-08-06)
 
 # 0.8.0 (2021-07-06)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
-- Pass UNIX path separators to `aapt` on non-UNIX systems, ensuring the resulting separator is compatible with the target device instead of the host platform.
+# 0.8.1 (2021-08-05)
+
+- Updated to use [ndk-build 0.4.2](../ndk-build/CHANGELOG.md#042-2021-08-05)
 
 # 0.8.0 (2021-07-06)
 

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-apk"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Helps cargo build APKs"
@@ -16,7 +16,7 @@ cargo-subcommand = "0.5.0"
 dunce = "1.0.1"
 env_logger = "0.8.2"
 log = "0.4.14"
-ndk-build = { path = "../ndk-build", version = "0.4.0" }
+ndk-build = { path = "../ndk-build", version = "0.4.2" }
 serde = "1.0.123"
 thiserror = "1.0.23"
 toml = "0.5.8"

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Fix NativeActivity library path on non-UNIX systems, which resulted in runtime crashes on startup.
+- Pass UNIX path separators to `aapt` on non-UNIX systems, ensuring the resulting separator is compatible with the target device instead of the host platform.
 
 # 0.4.1 (2021-08-02)
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.4.2 (2021-08-05)
+# 0.4.2 (2021-08-06)
 
 - Pass UNIX path separators to `aapt` on non-UNIX systems, ensuring the resulting separator is compatible with the target device instead of the host platform.
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix NativeActivity library path on non-UNIX systems, which resulted in runtime crashes on startup.
+
 # 0.4.1 (2021-08-02)
 
 - Only the highest platform supported by the NDK is now selected as default platform.

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.4.2 (2021-08-05)
+
 - Pass UNIX path separators to `aapt` on non-UNIX systems, ensuring the resulting separator is compatible with the target device instead of the host platform.
 
 # 0.4.1 (2021-08-02)

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-build"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Utilities for building Android binaries"

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -79,17 +79,19 @@ impl<'a> UnalignedApk<'a> {
             return Err(NdkError::PathNotFound(path.into()));
         }
         let abi = target.android_abi();
-        let file_name = path.file_name().unwrap().to_str().unwrap();
-
-        // aapt requires UNIX convention for the library path.
-        // Otherwise, it results in a runtime error when loading the NativeActivity .so library.
-        let lib_path_unix = format!("lib/{}/{}", abi, file_name);
-        let out = self.0.build_dir.join(&lib_path_unix);
+        let lib_path = Path::new("lib").join(abi).join(path.file_name().unwrap());
+        let out = self.0.build_dir.join(&lib_path);
         std::fs::create_dir_all(out.parent().unwrap())?;
         std::fs::copy(path, out)?;
 
+        // aapt requires UNIX convention for the library path.
+        // Otherwise, it results in a runtime error when loading the NativeActivity .so library.
+        let lib_path_unix = lib_path.to_str().unwrap().replace("\\", "/");
+
         let mut aapt = self.0.build_tool(bin!("aapt"))?;
-        aapt.arg("add").arg(self.0.unaligned_apk()).arg(lib_path_unix);
+        aapt.arg("add")
+            .arg(self.0.unaligned_apk())
+            .arg(lib_path_unix);
         if !aapt.status()?.success() {
             return Err(NdkError::CmdFailed(aapt));
         }

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -84,8 +84,9 @@ impl<'a> UnalignedApk<'a> {
         std::fs::create_dir_all(out.parent().unwrap())?;
         std::fs::copy(path, out)?;
 
-        // aapt requires UNIX convention for the library path.
-        // Otherwise, it results in a runtime error when loading the NativeActivity .so library.
+        // Pass UNIX path separators to `aapt` on non-UNIX systems, ensuring the resulting separator
+        // is compatible with the target device instead of the host platform.
+        // Otherwise, it results in a runtime error when loading the NativeActivity `.so` library.
         let lib_path_unix = lib_path.to_str().unwrap().replace("\\", "/");
 
         let mut aapt = self.0.build_tool(bin!("aapt"))?;


### PR DESCRIPTION
On Windows, using a backslash path for the library results in a runtime error where it fails to load the .so file.
```
prev: "lib/arm64-v8a/libhello_world.so"
new: "lib\\arm64-v8a\\libhello_world.so"
```
