### PR TITLE
Add missing safety docs

### DIFF
--- a/ndk-glue/src/lib.rs
+++ b/ndk-glue/src/lib.rs
@@ -128,6 +128,9 @@ pub enum Event {
     ContentRectChanged,
 }
 
+/// # Safety
+/// `activity` must either be null (resulting in a safe panic)
+/// or a pointer to a valid Android `ANativeActivity`.
 pub unsafe fn init(
     activity: *mut ANativeActivity,
     _saved_state: *mut u8,

--- a/ndk/src/aaudio.rs
+++ b/ndk/src/aaudio.rs
@@ -1182,6 +1182,9 @@ impl AAudioStream {
     /// * `buffer` - The slice with the samples.
     /// * `num_frames` - Number of frames to read. Only complete frames will be written.
     /// * `timeout_nanoseconds` - Maximum number of nanoseconds to wait for completion.
+    ///
+    /// # Safety
+    /// `buffer` must be a valid pointer to at least `num_frames` samples.
     pub unsafe fn read(
         &self,
         buffer: *mut c_void,
@@ -1314,6 +1317,9 @@ impl AAudioStream {
     /// * `buffer` - The address of the first sample.
     /// * `num_frames` - Number of frames to write. Only complete frames will be written.
     /// * `timeout_nanoseconds` - Maximum number of nanoseconds to wait for completion.
+    ///
+    /// # Safety
+    /// `buffer` must be a valid pointer to at least `num_frames` samples.
     pub unsafe fn write(
         &self,
         buffer: *const c_void,

--- a/ndk/src/asset.rs
+++ b/ndk/src/asset.rs
@@ -20,6 +20,7 @@ unsafe impl Sync for AssetManager {}
 impl AssetManager {
     /// Create an `AssetManager` from a pointer
     ///
+    /// # Safety
     /// By calling this function, you assert that the pointer is a valid pointer to a native
     /// `AAssetManager`.
     pub unsafe fn from_ptr(ptr: NonNull<ffi::AAssetManager>) -> Self {
@@ -98,6 +99,7 @@ impl AssetDir {
     /// `AAssetDir *` to the `AssetDir`, which will handle closing the asset.  Avoid using
     /// the pointer after calling this function.
     ///
+    /// # Safety
     /// By calling this function, you assert that it points to a valid native `AAssetDir`.
     pub unsafe fn from_ptr(ptr: NonNull<ffi::AAssetDir>) -> Self {
         Self { ptr }
@@ -174,6 +176,7 @@ impl Asset {
     /// the `Asset`, which will handle closing the asset.  Avoid using the pointer after calling
     /// this function.
     ///
+    /// # Safety
     /// By calling this function, you assert that it points to a valid native `AAsset`, open
     /// in the streaming mode.
     pub unsafe fn from_ptr(ptr: NonNull<ffi::AAsset>) -> Self {

--- a/ndk/src/configuration.rs
+++ b/ndk/src/configuration.rs
@@ -71,6 +71,7 @@ impl fmt::Debug for Configuration {
 impl Configuration {
     /// Construct a `Configuration` from a pointer.
     ///
+    /// # Safety
     /// By calling this function, you assert that it is a valid pointer to a native
     /// `AConfiguration`, and give ownership of it to the `Configuration` instance.
     pub unsafe fn from_ptr(ptr: NonNull<ffi::AConfiguration>) -> Self {
@@ -81,6 +82,10 @@ impl Configuration {
     /// the pointer.
     ///
     /// This is useful if you have a pointer, but not ownership of it.
+    ///
+    /// # Safety
+    /// By calling this function, you assert that it is a valid pointer to a native
+    /// `AConfiguration`.
     pub unsafe fn clone_from_ptr(ptr: NonNull<ffi::AConfiguration>) -> Self {
         let conf = Self::new();
         ffi::AConfiguration_copy(conf.ptr.as_ptr(), ptr.as_ptr());

--- a/ndk/src/event.rs
+++ b/ndk/src/event.rs
@@ -60,6 +60,7 @@ enum Class {
 impl InputEvent {
     /// Initialize an [`InputEvent`] from a pointer
     ///
+    /// # Safety
     /// By calling this function, you assert that the pointer is a valid pointer to a
     /// native [`AInputEvent`](ffi::AInputEvent).
     #[inline]
@@ -341,6 +342,7 @@ impl MotionEventFlags {
 impl MotionEvent {
     /// Constructs a MotionEvent from a pointer to a native [`AInputEvent`](ffi::AInputEvent)
     ///
+    /// # Safety
     /// By calling this method, you assert that the pointer is a valid, non-null pointer to a
     /// native [`AInputEvent`](ffi::AInputEvent) and that that [`AInputEvent`](ffi::AInputEvent)
     /// is an `AMotionEvent`.
@@ -1314,6 +1316,7 @@ pub enum Keycode {
 impl KeyEvent {
     /// Constructs a KeyEvent from a pointer to a native [`AInputEvent`](ffi::AInputEvent)
     ///
+    /// # Safety
     /// By calling this method, you assert that the pointer is a valid, non-null pointer to an
     /// [`AInputEvent`](ffi::AInputEvent), and that that [`AInputEvent`](ffi::AInputEvent) is an `AKeyEvent`.
     #[inline]

--- a/ndk/src/input_queue.rs
+++ b/ndk/src/input_queue.rs
@@ -23,6 +23,7 @@ pub struct InputQueueError;
 impl InputQueue {
     /// Construct an `InputQueue` from the native pointer.
     ///
+    /// # Safety
     /// By calling this function, you assert that the pointer is a valid pointer to an NDK `AInputQueue`.
     pub unsafe fn from_ptr(ptr: NonNull<ffi::AInputQueue>) -> Self {
         Self { ptr }

--- a/ndk/src/native_activity.rs
+++ b/ndk/src/native_activity.rs
@@ -24,6 +24,7 @@ unsafe impl Sync for NativeActivity {}
 impl NativeActivity {
     /// Create a `NativeActivity` from a pointer
     ///
+    /// # Safety
     /// By calling this function, you assert that it is a valid pointer to a native
     /// `ANativeActivity`.
     pub unsafe fn from_ptr(ptr: NonNull<ffi::ANativeActivity>) -> Self {
@@ -72,6 +73,7 @@ impl NativeActivity {
 
     /// Set the instance data associated with the activity
     ///
+    /// # Safety
     /// This can invalidate assumptions held by `android_native_app_glue`, as well as cause data
     /// races with concurrent access to the instance data.
     pub unsafe fn set_instance(&mut self, data: *mut c_void) {
@@ -119,6 +121,7 @@ impl NativeActivity {
 
     /// Path to the directory with the application's OBB files.
     ///
+    /// # Safety
     /// Only available as of Honeycomb (Android 3.0+, API level 11+)
     pub unsafe fn obb_path(&self) -> &CStr {
         CStr::from_ptr(self.ptr.as_ref().obbPath)

--- a/ndk/src/native_window.rs
+++ b/ndk/src/native_window.rs
@@ -10,6 +10,8 @@ unsafe impl Send for NativeWindow {}
 unsafe impl Sync for NativeWindow {}
 
 impl NativeWindow {
+    /// # Safety
+    /// `ptr` must be a valid pointer to an Android `ANativeWindow`.
     pub unsafe fn from_ptr(ptr: NonNull<ffi::ANativeWindow>) -> Self {
         Self { ptr }
     }


### PR DESCRIPTION
Filing this as a separate PR in preparation for `clippy` linting in the CI, just so that these nontrivial documentation changes can be reviewed properly.