### PR TITLE
ndk/looper: Drop boxed callback after deregistering

### DIFF
--- a/ndk/src/looper.rs
+++ b/ndk/src/looper.rs
@@ -265,33 +265,35 @@ impl ForeignLooper {
     ///
     /// See also [the NDK
     /// docs](https://developer.android.com/ndk/reference/group/looper.html#alooper_addfd).
-    pub fn add_fd_with_callback(
+    pub fn add_fd_with_callback<F: FnMut(RawFd) -> bool>(
         &self,
         fd: RawFd,
         ident: i32,
         events: FdEvent,
-        callback: Box<dyn FnMut(RawFd) -> bool>,
+        callback: Box<F>,
     ) -> Result<(), LooperError> {
-        extern "C" fn cb_handler(fd: RawFd, _events: i32, data: *mut c_void) -> i32 {
+        extern "C" fn cb_handler<F: FnMut(RawFd) -> bool>(
+            fd: RawFd,
+            _events: i32,
+            data: *mut c_void,
+        ) -> i32 {
             unsafe {
-                let mut cb = ManuallyDrop::new(Box::<Box<dyn FnMut(RawFd) -> bool>>::from_raw(
-                    data as *mut _,
-                ));
+                let mut cb = ManuallyDrop::new(Box::<F>::from_raw(data as *mut _));
                 let keep_registered = cb(fd);
                 if !keep_registered {
-                    let _ = ManuallyDrop::into_inner(cb);
+                    ManuallyDrop::into_inner(cb);
                 }
                 keep_registered as i32
             }
         }
-        let data: *mut c_void = Box::into_raw(Box::new(callback)) as *mut _;
+        let data = Box::into_raw(callback) as *mut _;
         match unsafe {
             ffi::ALooper_addFd(
                 self.ptr.as_ptr(),
                 fd,
                 ident,
                 events.bits() as i32,
-                Some(cb_handler),
+                Some(cb_handler::<F>),
                 data,
             )
         } {


### PR DESCRIPTION
The box created in `add_fd_with_callback` is turned into a raw pointer but its memory is never dropped when the callback requests for deregistration.

Note that it is still possible to deregister this callback using `ALooper_removeFd`, where the box cannot be accessed and would thus leak.  This is likely not a problem in practice because that function is not exposed in the safe API at the time of writing.
However, it is still possible to replace the callback by calling `ALooper_addFd` on the same `fd` again, leaking the boxes.

---

As an alternative we can write this in a (probably?) cleaner way by always converting back to a `Box` and instead preventing it from being dropped:

```rust
let mut cb = Box::<Box<dyn FnMut(RawFd) -> bool>>::from_raw(data as *mut _);
let keep_registered = cb(fd);
if keep_registered {
    forget(cb);
}
keep_registered as i32
```
Or, perhaps safer, wrap it in `ManuallyDrop` and explicitly drop it in `!keep_registered`.