### PR TITLE
ndk/looper: Pass ALOOPER_POLL_CALLBACK ident when adding fd callback

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- **Breaking:** Replace `add_fd_with_callback` `ident` with constant value `ALOOPER_POLL_CALLBACK`,
+  as per https://developer.android.com/ndk/reference/group/looper#alooper_addfd.
+
 # 0.4.0 (2021-08-02)
 
 - **Breaking:** Model looper file descriptor events integer as `bitflags`.

--- a/ndk/src/looper.rs
+++ b/ndk/src/looper.rs
@@ -268,7 +268,6 @@ impl ForeignLooper {
     pub fn add_fd_with_callback<F: FnMut(RawFd) -> bool>(
         &self,
         fd: RawFd,
-        ident: i32,
         events: FdEvent,
         callback: Box<F>,
     ) -> Result<(), LooperError> {
@@ -291,7 +290,7 @@ impl ForeignLooper {
             ffi::ALooper_addFd(
                 self.ptr.as_ptr(),
                 fd,
-                ident,
+                ffi::ALOOPER_POLL_CALLBACK,
                 events.bits() as i32,
                 Some(cb_handler::<F>),
                 data,


### PR DESCRIPTION
According to [the documentation]: `The identifier must be >= 0, or ALOOPER_POLL_CALLBACK if providing a non-NULL callback.` This makes sense because the identifier is not returned anywhere when the callback fires.

[the documentation]: https://developer.android.com/ndk/reference/group/looper#alooper_removefd
