### PR TITLE
ndk-glue: Document lock behaviour in `Event` and ensure pointer equality

### DIFF
--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Document when to lock and unlock the window/input queue when certain events are received.
+
 # 0.4.0 (2021-08-02)
 
 - Looper is now created before returning from `ANativeActivity_onCreate`, solving

--- a/ndk-glue/src/lib.rs
+++ b/ndk-glue/src/lib.rs
@@ -122,8 +122,16 @@ pub enum Event {
     WindowCreated,
     WindowResized,
     WindowRedrawNeeded,
+    /// If the window is in use by ie. a graphics API, make sure the lock from
+    /// [`native_window()`] is held on to until after freeing those resources.
+    ///
+    /// After receiving this [`Event`] `ndk_glue` will block until that read-lock
+    /// is released before returning to Android and allowing it to free up the window.
     WindowDestroyed,
     InputQueueCreated,
+    /// After receiving this [`Event`] `ndk_glue` will block until the read-lock from
+    /// [`input_queue()`] is released before returning to Android and allowing it to
+    /// free up the input queue.
     InputQueueDestroyed,
     ContentRectChanged,
 }
@@ -281,10 +289,12 @@ unsafe extern "C" fn on_window_redraw_needed(
 
 unsafe extern "C" fn on_window_destroyed(
     activity: *mut ANativeActivity,
-    _window: *mut ANativeWindow,
+    window: *mut ANativeWindow,
 ) {
     wake(activity, Event::WindowDestroyed);
-    *NATIVE_WINDOW.write().unwrap() = None;
+    let mut native_window_guard = NATIVE_WINDOW.write().unwrap();
+    assert_eq!(native_window_guard.as_ref().unwrap().ptr().as_ptr(), window);
+    *native_window_guard = None;
 }
 
 unsafe extern "C" fn on_input_queue_created(


### PR DESCRIPTION
This completes #134 by applying the same pointer-equality check in `on_input_queue_destroyed` to `on_window_destroyed`, and documents when the user should hold on to or release any of the `RWLock`s to ensure proper lifetimes for dependencies like surfaces in graphics APIs.
