### PR TITLE
cargo-apk: Fixed the library name in case of multiple build artifacts 

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed the library name in case of multiple build artifacts in the Android manifest.
+
 # 0.8.1 (2021-08-06)
 
 - Updated to use [ndk-build 0.4.2](../ndk-build/CHANGELOG.md#042-2021-08-06)

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -67,16 +67,6 @@ impl<'a> ApkBuilder<'a> {
             .debuggable
             .get_or_insert(*cmd.profile() == Profile::Dev);
 
-        manifest
-            .android_manifest
-            .application
-            .activity
-            .meta_data
-            .push(MetaData {
-                name: "android.app.lib_name".to_string(),
-                value: cmd.artifacts()[0].name().replace("-", "_"),
-            });
-
         Ok(Self {
             cmd,
             ndk,
@@ -120,6 +110,11 @@ impl<'a> ApkBuilder<'a> {
         if manifest.application.label.is_empty() {
             manifest.application.label = artifact.name().to_string();
         }
+
+        manifest.application.activity.meta_data.push(MetaData {
+            name: "android.app.lib_name".to_string(),
+            value: artifact.name().replace("-", "_"),
+        });
 
         let crate_path = self.cmd.manifest().parent().expect("invalid manifest path");
 


### PR DESCRIPTION
When specifying multiple build targets (e.g --examples) only the first artifact was used to derive the library name.
In the `AndroidManifest.xml` the key `android:name="android.app.lib_name"` would always have the same value for each artifact. The resulting application wouldn't be able to correctly load the library on runtime.

This surfaced in the CI changes https://github.com/rust-windowing/android-ndk-rs/pull/169 which builds all examples with a single command. The uploaded apk artifacts may not run correctly as they internally refer to the jni-audio library.