### PR TITLE
ndk/looper: Accept unboxed closure in add_fd_with_callback

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **Breaking:** Replace `add_fd_with_callback` `ident` with constant value `ALOOPER_POLL_CALLBACK`,
   as per https://developer.android.com/ndk/reference/group/looper#alooper_addfd.
+- **Breaking:** Accept unboxed closure in `add_fd_with_callback`.
 
 # 0.4.0 (2021-08-02)
 

--- a/ndk/src/looper.rs
+++ b/ndk/src/looper.rs
@@ -269,7 +269,7 @@ impl ForeignLooper {
         &self,
         fd: RawFd,
         events: FdEvent,
-        callback: Box<F>,
+        callback: F,
     ) -> Result<(), LooperError> {
         extern "C" fn cb_handler<F: FnMut(RawFd) -> bool>(
             fd: RawFd,
@@ -285,7 +285,7 @@ impl ForeignLooper {
                 keep_registered as i32
             }
         }
-        let data = Box::into_raw(callback) as *mut _;
+        let data = Box::into_raw(Box::new(callback)) as *mut _;
         match unsafe {
             ffi::ALooper_addFd(
                 self.ptr.as_ptr(),


### PR DESCRIPTION
For https://github.com/rust-windowing/android-ndk-rs/pull/172#discussion_r684681058

b0f2148 ("ndk/looper: Drop boxed callback after deregistering (#172)") improved `add_fd_with_callback` to use a generic type instead of `dyn FnMut`, allowing us to get rid of a double `Box` that would otherwise be needed to hold the fat pointer with vtable.  Since the API is changing for the next `ndk` release anyway (`ident` has been removed as this has to use the `ALOOPER_POLL_CALLBACK` constant) we can also remove the `Box` implementation detail.  A new `Box` is still created just like the previous implementation though, since the lifetime of the closure is now unknown (at least as long as Android might be calling it).
