### PR TITLE
ndk: Add missing `feature="api-level-XX"` guards

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -4,6 +4,7 @@
   as per https://developer.android.com/ndk/reference/group/looper#alooper_addfd.
 - **Breaking:** Accept unboxed closure in `add_fd_with_callback`.
 - ndk/aaudio: Replace "Added in" comments with missing `#[cfg(feature)]`
+- ndk/aaudio: Add missing `fn get_allowed_capture_policy()`
 
 # 0.4.0 (2021-08-02)
 

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking:** Accept unboxed closure in `add_fd_with_callback`.
 - ndk/aaudio: Replace "Added in" comments with missing `#[cfg(feature)]`
 - ndk/aaudio: Add missing `fn get_allowed_capture_policy()`
+- ndk/configuration: Add missing `api-level-30` feature to `fn screen_round()`
 
 # 0.4.0 (2021-08-02)
 

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **Breaking:** Replace `add_fd_with_callback` `ident` with constant value `ALOOPER_POLL_CALLBACK`,
   as per https://developer.android.com/ndk/reference/group/looper#alooper_addfd.
 - **Breaking:** Accept unboxed closure in `add_fd_with_callback`.
+- ndk/aaudio: Replace "Added in" comments with missing `#[cfg(feature)]`
 
 # 0.4.0 (2021-08-02)
 

--- a/ndk/src/aaudio.rs
+++ b/ndk/src/aaudio.rs
@@ -914,6 +914,13 @@ impl AAudioStream {
         self.inner.as_ptr()
     }
 
+    /// Returns the policy that determines whether the audio may or
+    /// may not be captured by other apps or the system.
+    #[cfg(feature = "api-level-29")]
+    pub fn get_allowed_capture_policy(self) -> Result<AAudioAllowedCapturePolicy> {
+        enum_return_value(unsafe { ffi::AAudioStream_getAllowedCapturePolicy(self.as_ptr()) })
+    }
+
     /// Query maximum buffer capacity in frames.
     ///
     /// Available since API level 26.

--- a/ndk/src/aaudio.rs
+++ b/ndk/src/aaudio.rs
@@ -20,8 +20,7 @@ use thiserror::Error;
 ///
 /// Note that these match the equivalent values in android.media.AudioAttributes
 /// in the Android Java API.
-///
-/// Added in API level 29.
+#[cfg(feature = "api-level-29")]
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
 pub enum AAudioAllowedCapturePolicy {
@@ -58,8 +57,7 @@ pub enum AAudioAllowedCapturePolicy {
 ///
 /// Note that these match the equivalent values in android.media.AudioAttributes
 /// in the Android Java API.
-///
-/// Added in API level 28.
+#[cfg(feature = "api-level-28")]
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
 pub enum AAudioContentType {
@@ -106,8 +104,7 @@ pub enum AAudioFormat {
 /// configuration.
 ///
 /// Note that these match the equivalent values in MediaRecorder.AudioSource in the Android Java API.
-///
-/// Added in API level 28.
+#[cfg(feature = "api-level-28")]
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
 pub enum AAudioInputPreset {
@@ -126,7 +123,7 @@ pub enum AAudioInputPreset {
     /// Use this preset for capturing audio meant to be processed in real time
     /// and played back for live performance (e.g karaoke).
     /// The capture path will minimize latency and coupling with playback path.
-    /// Available since API level 29.
+    #[cfg(feature = "api-level-29")]
     VoicePerformance = ffi::AAUDIO_INPUT_PRESET_VOICE_PERFORMANCE,
 }
 
@@ -162,8 +159,7 @@ pub enum AAudioSharingMode {
 ///
 /// Note that these match the equivalent values in android.media.AudioAttributes
 /// in the Android Java API.
-///
-/// Added in API level 28.
+#[cfg(feature = "api-level-28")]
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
 pub enum AAudioUsage {

--- a/ndk/src/configuration.rs
+++ b/ndk/src/configuration.rs
@@ -264,6 +264,7 @@ impl Configuration {
         }
     }
 
+    #[cfg(feature = "api-level-30")]
     pub fn screen_round(&self) -> ScreenRound {
         unsafe {
             (ffi::AConfiguration_getScreenRound(self.ptr.as_ptr()) as u32)


### PR DESCRIPTION
- ndk/aaudio: Replace "Added in" comments with missing `#[cfg(feature)]`
- ndk/aaudio: Add missing `fn get_allowed_capture_policy()`
- ndk/configuration: Add missing `api-level-30` to `screen_round()`
