### PR TITLE
Wrap video coding APIs

### DIFF
--- a/ndk-sys/wrapper.h
+++ b/ndk-sys/wrapper.h
@@ -45,3 +45,10 @@
 
 #include <media/NdkImage.h>
 #include <media/NdkImageReader.h>
+#include <media/NdkMediaCodec.h> 
+#include <media/NdkMediaCrypto.h> 
+#include <media/NdkMediaDrm.h> 
+#include <media/NdkMediaError.h> 
+#include <media/NdkMediaExtractor.h> 
+#include <media/NdkMediaFormat.h> 
+#include <media/NdkMediaMuxer.h>


### PR DESCRIPTION
Add support for `AMediaCodec` to ndk-sys. I tried to generate the bindings but I was not able to.