### PR TITLE
Avoid AAPT errors stemming from attempts of adding the same library twice

### DIFF
--- a/ndk-build/src/readelf.rs
+++ b/ndk-build/src/readelf.rs
@@ -51,8 +51,9 @@ impl<'a> UnalignedApk<'a> {
                 };
 
                 if let Some(path) = find_library_path(search_paths, &need)? {
-                    provided.insert(path.file_name().unwrap().to_str().unwrap().to_string());
-                    artifacts.push(path);
+                    if provided.insert(path.file_name().unwrap().to_str().unwrap().to_string()) {
+                        artifacts.push(path);
+                    }
                 } else {
                     eprintln!("Shared library \"{}\" not found.", need);
                 }


### PR DESCRIPTION
Fixes #186.