### PR TITLE
cargo-apk: Work around missing libgcc on NDK r23 with linker script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,13 @@ Branch | Version | Status | Working
 r18 | 18.1.5063045 | _Deprecated_ | :x:
 r19 | 19.2.5345600 | _Deprecated_ | :heavy_check_mark:
 r20 | 20.1.5948944 | _Deprecated_ | :heavy_check_mark:
-r21 | 21.4.7075529 | LTS | :heavy_check_mark:
-r22 | 22.1.7171670 | Rolling Release | :heavy_check_mark:
-r23 beta 1/2 |  | Beta | :heavy_check_mark:
-r23 beta 3 and beyond |  | Beta | :x: Breaking on [#149](https://github.com/rust-windowing/android-ndk-rs/issues/149) :x:
+r21 | 21.4.7075529 | _Deprecated_ | :heavy_check_mark:
+r22 | 22.1.7171670 | _Deprecated_ | :heavy_check_mark:
+r23 | beta 1/2 | _Deprecated_ | :heavy_check_mark:
+r23 | 23.0.7272597-beta3 | _Deprecated_ | :heavy_check_mark: Workaround in [#189](https://github.com/rust-windowing/android-ndk-rs/pull/189)
+r23 | 23.1.7779620 | LTS | :heavy_check_mark: Workaround in [#189](https://github.com/rust-windowing/android-ndk-rs/pull/189)
+r24 | 24.0.7856742-beta1 | Rolling Release | :heavy_check_mark: Workaround in [#189](https://github.com/rust-windowing/android-ndk-rs/pull/189)
+
 
 ## Hello world
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - Fixed the library name in case of multiple build artifacts in the Android manifest.
+- Work around missing `libgcc` on NDK r23 beta 3 and above, by providing linker script that "redirects" to `libunwind`.
+  See https://github.com/rust-windowing/android-ndk-rs/issues/149 and https://github.com/rust-lang/rust/pull/85806 for more details.
 
 # 0.8.1 (2021-08-06)
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Provide NDK `build_tag` version from `source.properties` in the NDK root.
+
 # 0.4.2 (2021-08-06)
 
 - Pass UNIX path separators to `aapt` on non-UNIX systems, ensuring the resulting separator is compatible with the target device instead of the host platform.


### PR DESCRIPTION
Fixes #149

Rust still searches for libgcc even though [85806] replaces internal use with libunwind, especially now that the Android NDK (since r23-beta3) doesn't ship with any of gcc anymore.  The apparent solution is to build your application with nightly and compile std locally (`-Zbuild-std`), but that is not desired for the majority of users.  [7339] suggests to provide a local `libgcc.a` as linker script, which simply redirects linking to `libunwind` instead - and that has proven to work fine so far.

Intead of shipping this file with the crate or writing it to an existing link-search directory on the system, we write it to a new directory that can be easily passed or removed to `rustc`, say in the event that a user switches to an older NDK and builds without cleaning.  For this we need to switch from `cargo build` to `cargo rustc`, but the existing arguments and desired workflow remain identical.

[85806]: https://github.com/rust-lang/rust/pull/85806
[7339]: https://github.com/termux/termux-packages/pull/7339#issuecomment-921581430