### PR TITLE
Release ndk-sys-0.2.2, ndk-0.5.0, ndk-macro-0.3.0, ndk-glue-0.5.0

### DIFF
--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
+# 0.5.0 (2021-11-16)
+
 - Document when to lock and unlock the window/input queue when certain events are received.
+- **Breaking:** Update to `ndk 0.5.0` and `ndk-macros 0.3.0`.
 
 # 0.4.0 (2021-08-02)
 

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-glue"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Startup code for android binaries"
@@ -12,9 +12,9 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
-ndk = { path = "../ndk", version = "0.4.0" }
-ndk-sys = { path = "../ndk-sys", version = "0.2.1" }
-ndk-macro = { path = "../ndk-macro", version = "0.2.0" }
+ndk = { path = "../ndk", version = "0.5.0" }
+ndk-sys = { path = "../ndk-sys", version = "0.2.2" }
+ndk-macro = { path = "../ndk-macro", version = "0.3.0" }
 lazy_static = "1.4.0"
 libc = "0.2.84"
 log = "0.4.14"

--- a/ndk-macro/CHANGELOG.md
+++ b/ndk-macro/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
-- Removed `android_logger` and `log` crate path overrides from macro input attributes in favour of using the reexports from `ndk-glue`.
+# 0.3.0 (2021-11-16)
+
+- **Breaking:** Removed `android_logger` and `log` crate path overrides from macro input attributes in favour of using the reexports from `ndk-glue`.
   Applications no longer have to provide these crates in scope of the `ndk_glue::main` macro when logging is enabled.
 
 # 0.2.0 (2020-09-15)

--- a/ndk-macro/Cargo.toml
+++ b/ndk-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-macro"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Helper macros for android ndk"

--- a/ndk-sys/CHANGELOG.md
+++ b/ndk-sys/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.2.2 (2021-11-16)
+
 - Regenerate against NDK r23 (#178)
 
 # 0.2.1 (2020-10-15)

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-sys"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "FFI bindings for the Android NDK"

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.5.0 (2021-11-16)
+
 - **Breaking:** Replace `add_fd_with_callback` `ident` with constant value `ALOOPER_POLL_CALLBACK`,
   as per https://developer.android.com/ndk/reference/group/looper#alooper_addfd.
 - **Breaking:** Accept unboxed closure in `add_fd_with_callback`.

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Safe Rust bindings to the Android NDK"
@@ -48,7 +48,7 @@ optional = true
 [dependencies.ffi]
 package = "ndk-sys"
 path = "../ndk-sys"
-version = "0.2.1"
+version = "0.2.2"
 
 [package.metadata.docs.rs]
 features = ["jni", "jni-glue", "all"]


### PR DESCRIPTION
Bump versions for all crates providing Android-specific code.
