### PR TITLE
Release ndk-build-0.4.3, cargo-apk-0.8.2

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.8.2 (2021-11-16)
+# 0.8.2 (2021-11-22)
 
 - Fixed the library name in case of multiple build artifacts in the Android manifest.
 - Work around missing `libgcc` on NDK r23 beta 3 and above, by providing linker script that "redirects" to `libunwind`.

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.8.2 (2021-11-16)
+
 - Fixed the library name in case of multiple build artifacts in the Android manifest.
 - Work around missing `libgcc` on NDK r23 beta 3 and above, by providing linker script that "redirects" to `libunwind`.
   See https://github.com/rust-windowing/android-ndk-rs/issues/149 and https://github.com/rust-lang/rust/pull/85806 for more details.

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-apk"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Helps cargo build APKs"
@@ -16,7 +16,7 @@ cargo-subcommand = "0.5.0"
 dunce = "1.0.1"
 env_logger = "0.8.2"
 log = "0.4.14"
-ndk-build = { path = "../ndk-build", version = "0.4.2" }
+ndk-build = { path = "../ndk-build", version = "0.4.3" }
 serde = "1.0.123"
 thiserror = "1.0.23"
 toml = "0.5.8"

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.4.3 (2021-11-16)
+# 0.4.3 (2021-11-22)
 
 - Provide NDK `build_tag` version from `source.properties` in the NDK root.
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.4.3 (2021-11-16)
+
 - Provide NDK `build_tag` version from `source.properties` in the NDK root.
 
 # 0.4.2 (2021-08-06)

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-build"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Utilities for building Android binaries"

--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.5.0 (2021-11-16)
+# 0.5.0 (2021-11-22)
 
 - Document when to lock and unlock the window/input queue when certain events are received.
 - **Breaking:** Update to `ndk 0.5.0` and `ndk-macros 0.3.0`.

--- a/ndk-macro/CHANGELOG.md
+++ b/ndk-macro/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.3.0 (2021-11-16)
+# 0.3.0 (2021-11-22)
 
 - **Breaking:** Removed `android_logger` and `log` crate path overrides from macro input attributes in favour of using the reexports from `ndk-glue`.
   Applications no longer have to provide these crates in scope of the `ndk_glue::main` macro when logging is enabled.

--- a/ndk-sys/CHANGELOG.md
+++ b/ndk-sys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.2.2 (2021-11-16)
+# 0.2.2 (2021-11-22)
 
 - Regenerate against NDK r23 (#178)
 

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.5.0 (2021-11-16)
+# 0.5.0 (2021-11-22)
 
 - **Breaking:** Replace `add_fd_with_callback` `ident` with constant value `ALOOPER_POLL_CALLBACK`,
   as per https://developer.android.com/ndk/reference/group/looper#alooper_addfd.


### PR DESCRIPTION
Bump versions for the host tooling.
