### PR TITLE
cargo-apk: Use `min_sdk_version` to select compiler target

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Use `min_sdk_version` to select compiler target instead of `target_sdk_version` ([#197](https://github.com/rust-windowing/android-ndk-rs/pull/197)).
+  See https://developer.android.com/ndk/guides/sdk-versions#minsdkversion for more details.
+
 # 0.8.2 (2021-11-22)
 
 - Fixed the library name in case of multiple build artifacts in the Android manifest.


### PR DESCRIPTION
Fixes #193, cc @hrydgard 

According to [1] minSdkVersion is used to determine the compiler target and ultimately limit what API is available at compile-time.  This is most likely because using/linking newer API will result in runtime linker errors on these older platforms.

[1]: https://developer.android.com/ndk/guides/sdk-versions#minsdkversion

---

I think we still have a couple things to do here:
- Now that `min_sdk_version` is mandatory (see the unwrap), perhaps we should default it to the _minimum_ SDK level available in the NDK (the `min()` of `default_platform()`)?;
  (obviously reword the defaults in the cargo-apk docs);
- Remove the "arbitrary" default of minimum version 23?  Does anyone recall why this was chosen?  NDK r24 beta still ships with support for SDK level 21, which would then be the lowest;
- Is `targetSdkVersion` still mandatory?  If so, does it still make sense to set it to the max available in the SDK?;
- when we have these defaults, should we remove the arbitrary overrides in `ndk-examples`?
