### PR TITLE
ci emulator: Disable animations and other UI/UX features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
         arch: x86_64
         # the `googleapis` emulator target is considerably slower on CI.
         target: default
-        profile: Nexus 5X
+        profile: Nexus 6
         script: ./.github/workflows/android_test.sh "${{ steps.download.outputs.download-path }}"
     - name: Upload emulator logs
       uses: actions/upload-artifact@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -116,6 +116,8 @@ jobs:
         # the `googleapis` emulator target is considerably slower on CI.
         target: default
         profile: Nexus 6
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
         script: ./.github/workflows/android_test.sh "${{ steps.download.outputs.download-path }}"
     - name: Upload emulator logs
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
We only care about starting a very simple UI-less app for now, and this seems to fix the deadlock that occurs right about every CI emulator job just before `adb install` runs.  It hopefully also makes the runs a bit faster, but this wasn't measured/compared in detail due to already high runtime variance.
