### PR TITLE
ndk-build,cargo-apk: Default `target_sdk_version` to 30 or lower

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Use `min_sdk_version` to select compiler target instead of `target_sdk_version` ([#197](https://github.com/rust-windowing/android-ndk-rs/pull/197)).
   See https://developer.android.com/ndk/guides/sdk-versions#minsdkversion for more details.
+- Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
+  for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
+  https://developer.android.com/distribute/best-practices/develop/target-sdk
 
 # 0.8.2 (2021-11-22)
 

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -49,10 +49,10 @@ runtime_libs = "path/to/libs_folder"
 
 # See https://developer.android.com/guide/topics/manifest/uses-sdk-element
 #
-# Defaults to a `min_sdk_version` of 23 and `target_sdk_version` is based on the ndk's default platform.
+# Defaults to a `min_sdk_version` of 23 and `target_sdk_version` of 30 (or lower if the detected NDK doesn't support this).
 [package.metadata.android.sdk]
-min_sdk_version = 16
-target_sdk_version = 29
+min_sdk_version = 23
+target_sdk_version = 30
 max_sdk_version = 29
 
 # See https://developer.android.com/guide/topics/manifest/uses-feature-element

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -59,13 +59,13 @@ impl<'a> ApkBuilder<'a> {
             .android_manifest
             .sdk
             .target_sdk_version
-            .get_or_insert(ndk.default_platform());
+            .get_or_insert_with(|| ndk.default_target_platform());
 
         manifest
             .android_manifest
             .application
             .debuggable
-            .get_or_insert(*cmd.profile() == Profile::Dev);
+            .get_or_insert_with(|| *cmd.profile() == Profile::Dev);
 
         Ok(Self {
             cmd,

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
+  for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
+  https://developer.android.com/distribute/best-practices/develop/target-sdk
+
 # 0.4.3 (2021-11-22)
 
 - Provide NDK `build_tag` version from `source.properties` in the NDK root.
@@ -23,7 +27,7 @@
 
 # 0.2.0 (2021-04-20)
 
-- **Breaking:** refactored `Manifest` into a proper (de)serialization struct. `Manifest` now closely matches [`an android manifest file`](https://developer.android.com/guide/topics/manifest/manifest-element).
+- **Breaking:** refactored `Manifest` into a proper (de)serialization struct. `Manifest` now closely matches [an android manifest file](https://developer.android.com/guide/topics/manifest/manifest-element).
 - **Breaking:** removed `Config` in favor of using the new `Manifest` struct directly. Instead of using `Config::from_config` to create a `Manifest`, now you instantiate `Manifest` directly using, almost all, the same values.
 
 # 0.1.4 (2020-11-25)

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -40,7 +40,7 @@ impl ApkConfig {
             .manifest
             .sdk
             .target_sdk_version
-            .unwrap_or_else(|| self.ndk.default_platform());
+            .unwrap_or_else(|| self.ndk.default_target_platform());
         let mut aapt = self.build_tool(bin!("aapt"))?;
         aapt.arg("package")
             .arg("-f")

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -159,8 +159,16 @@ impl Ndk {
         Ok(Command::new(dunce::canonicalize(path)?))
     }
 
-    pub fn default_platform(&self) -> u32 {
+    pub fn highest_supported_platform(&self) -> u32 {
         self.platforms().iter().max().cloned().unwrap()
+    }
+
+    /// Returns platform `30` as currently [required by Google Play], or lower
+    /// when the detected SDK does not support it yet.
+    ///
+    /// [required by Google Play]: https://developer.android.com/distribute/best-practices/develop/target-sdk
+    pub fn default_target_platform(&self) -> u32 {
+        self.highest_supported_platform().min(30)
     }
 
     pub fn platform_dir(&self, platform: u32) -> Result<PathBuf, NdkError> {


### PR DESCRIPTION
Depends on #197

As discussed in [197] setting `target_sdk_version` to the "arbitrary" highest available SDK version is nonsense.  This target version (unlike `min_sdk_version` which defines the least set of symbols that should be available) has real impact on the runtime of an application, in particular the compatibility or stringency of rules Android applies to your application.  Certain APIs may not work at all or be heavily restricted on newer target versions because they are deemed too dangerous, and Android expects the user has tested their app against these limitations and is communicating this by setting `target_sdk_version` to that particular value.  Hence this shouldn't change purely based on the environment, even for the default.

To retain some backwards compatibility with previous `cargo-apk` we set this to level 30 which is the least [required by Google Play] today, and exactly what users will have been targeting using NDK r22 (assuming the SDK for this `platform` was installed as well) since SDK version 31 support with NDK r23 only [arrived just last week].

[197]: https://github.com/rust-windowing/android-ndk-rs/pull/197#issuecomment-970283527
[required by Google Play]: https://developer.android.com/distribute/best-practices/develop/target-sdk
[arrived just last week]: https://github.com/rust-windowing/android-ndk-rs/pull/189

Thanks @hrydgard for bringing this to my attention!