### PR TITLE
Add android:exported support in manifest

### DIFF
--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -123,6 +123,11 @@ launch_mode = "singleTop"
 # Defaults to "unspecified".
 orientation = "landscape"
 
+# See https://developer.android.com/guide/topics/manifest/activity-element#exported
+#
+# Defaults to "unspecified".
+exported = "true"
+
 # See https://developer.android.com/guide/topics/manifest/meta-data-element
 #
 # Note: there can be several .meta_data entries.

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -93,6 +93,8 @@ pub struct Activity {
     pub name: String,
     #[serde(rename(serialize = "android:screenOrientation"))]
     pub orientation: Option<String>,
+    #[serde(rename(serialize = "android:exported"))]
+    pub exported: Option<bool>,
 
     #[serde(rename(serialize = "meta-data"))]
     #[serde(default)]
@@ -112,6 +114,7 @@ impl Default for Activity {
             launch_mode: None,
             name: default_activity_name(),
             orientation: None,
+            exported: None,
             meta_data: Default::default(),
             intent_filter: Default::default(),
         }


### PR DESCRIPTION
This attribute is now required when targeting android 12 : https://developer.android.com/about/versions/12/behavior-changes-12#exported