### PR TITLE
ndk/native_window: Use `release`/`acquire` fns for `Drop` and `Clone`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Breaking:** `Configuration::country()` now returns `None` when the country is unset (akin to `Configuration::language()`)
 - Add `MediaCodec` and `MediaFormat` bindings. (#216)
 - **Breaking:** Upgrade to [`ndk-sys 0.4.0`](../ndk-sys/CHANGELOG.md#040-TODO-YET-UNRELEASED) and use new `enum` newtype wrappers. (#245)
+- ndk/native_window: Use `release`/`acquire` for `Drop` and `Clone` respectively. (#207)
 
 # 0.6.0 (2022-01-05)
 

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -384,13 +384,13 @@ impl MediaCodec {
     }
 
     #[cfg(feature = "api-level-26")]
-    pub fn set_input_surface(&self, surface: NativeWindow) -> Result<()> {
+    pub fn set_input_surface(&self, surface: &NativeWindow) -> Result<()> {
         let status =
             unsafe { ffi::AMediaCodec_setInputSurface(self.as_ptr(), surface.ptr().as_ptr()) };
         NdkMediaError::from_status(status)
     }
 
-    pub fn set_output_surface(&self, surface: NativeWindow) -> Result<()> {
+    pub fn set_output_surface(&self, surface: &NativeWindow) -> Result<()> {
         let status =
             unsafe { ffi::AMediaCodec_setOutputSurface(self.as_ptr(), surface.ptr().as_ptr()) };
         NdkMediaError::from_status(status)


### PR DESCRIPTION
Much like ALooper and AHardwareBuffer the reference counter of ANativeWindow must be properly incremented on `Clone`, in turn allowing us to also `_release` the window as soon as it is dropped.
