### PR TITLE
Make `HardwareBuffer::as_ptr()` public

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- ndk/media/image_reader: Make `HardwareBuffer::as_ptr()` public for interop with Vulkan.
+
 # 0.6.0 (2022-01-05)
 
 - **Breaking:** Upgrade to `ndk-sys 0.3.0` and migrate to `jni-sys` types that it now directly uses in its bindings.

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -131,7 +131,7 @@ impl HardwareBuffer {
         Self { inner: ptr }
     }
 
-    fn as_ptr(&self) -> *mut ffi::AHardwareBuffer {
+    pub fn as_ptr(&self) -> *mut ffi::AHardwareBuffer {
         self.inner.as_ptr()
     }
 

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -131,6 +131,11 @@ impl HardwareBuffer {
         Self { inner: ptr }
     }
 
+    /// Returns the underlying [`ffi::AHardwareBuffer`] pointer
+    ///
+    /// The pointer can be used to import this hardware buffer into a Vulkan memory object using [`VK_ANDROID_external_memory_android_hardware_buffer`].
+    ///
+    /// [`VK_ANDROID_external_memory_android_hardware_buffer`]: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_ANDROID_external_memory_android_hardware_buffer.html
     pub fn as_ptr(&self) -> *mut ffi::AHardwareBuffer {
         self.inner.as_ptr()
     }


### PR DESCRIPTION
~I suppose this was a mistake because there is no other way of accessing the underlying pointer.~ It probably isn't a mistake since other structs also have `as_ptr()` private. But `HardwareBuffer` should be spacial and have `as_ptr()` public, I need the pointer to import the memory into Vulkan.