### PR TITLE
cargo-apk: Add `cargo apk version` command for querying release version

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Allow manifest `package` property to be provided in `Cargo.toml`. ([#236](https://github.com/rust-windowing/android-ndk-rs/pull/236))
 - Add `MAIN` intent filter in `from_subcommand` instead of relying on a custom serialization function in `ndk-build`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
 - Export the sole `NativeActivity` (through `android:exported="true"`) to allow it to be started by default if targeting Android S or higher. ([#242](https://github.com/rust-windowing/android-ndk-rs/pull/242))
+- `cargo-apk` version can now be queried through `cargo apk version`
 
 # 0.8.2 (2021-11-22)
 

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -39,6 +39,9 @@ fn main() -> anyhow::Result<()> {
                 print_help();
             }
         }
+        "version" => {
+            println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        }
         _ => print_help(),
     }
 
@@ -66,6 +69,7 @@ SUBCOMMAND:
     build, b    Compiles the current package and creates an apk
     run, r      Run a binary or example of the local package
     gdb         Start a gdb session attached to an adb device with symbols loaded
+    version     Print the version of cargo-apk
 "#
     );
 }


### PR DESCRIPTION
Print the package name and version from `Cargo.toml` that the crate/binary was built with.

Note that we still have to address [EDIT: don't use the word `fix` here to not trigger auto issue linking] #217 somehow to make this truly useful, without having to switch to a directory that contains a valid crate setup.
