### PR TITLE
ndk: Remove and warn on trivial casts

### DIFF
--- a/ndk/src/configuration.rs
+++ b/ndk/src/configuration.rs
@@ -136,7 +136,7 @@ impl Configuration {
     pub fn country(&self) -> Option<String> {
         let mut chars = [0u8; 2];
         unsafe {
-            ffi::AConfiguration_getCountry(self.ptr.as_ptr(), chars.as_mut_ptr() as *mut _);
+            ffi::AConfiguration_getCountry(self.ptr.as_ptr(), chars.as_mut_ptr().cast());
         }
         if chars[0] == 0 {
             None
@@ -180,7 +180,7 @@ impl Configuration {
     pub fn language(&self) -> Option<String> {
         let mut chars = [0u8; 2];
         unsafe {
-            ffi::AConfiguration_getLanguage(self.ptr.as_ptr(), chars.as_mut_ptr() as *mut _);
+            ffi::AConfiguration_getLanguage(self.ptr.as_ptr(), chars.as_mut_ptr().cast());
         }
         if chars[0] == 0 {
             None

--- a/ndk/src/lib.rs
+++ b/ndk/src/lib.rs
@@ -13,7 +13,7 @@
     feature = "native_app_glue",
     doc = "  * `native_app_glue`'s `AndroidApp`, in the `android_app` module"
 )]
-#![warn(missing_debug_implementations)]
+#![warn(missing_debug_implementations, trivial_casts)]
 
 pub mod asset;
 pub mod bitmap;

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -1,5 +1,3 @@
-#![warn(trivial_casts)]
-
 use super::{construct, construct_never_null, NdkMediaError, Result};
 use crate::native_window::NativeWindow;
 use std::{


### PR DESCRIPTION
`trivial-casts` is allowed by default as it still has some odd cases where the lint triggers incorrectly or is difficult to fix.  For our intents and purposes however it works just fine and prevents against riddling the code with unnecessary - usually untyped - `as` casts.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#explanation-22

CC @zarik5, #216
