### PR TITLE
ndk/configuration: Return `None` from `fn country()` when unset

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - ndk/media/image_reader: Make `HardwareBuffer::as_ptr()` public for interop with Vulkan.
+- **Breaking:** `Configuration::country()` now returns `None` when the country is unset (akin to `Configuration::language()`)
 
 # 0.6.0 (2022-01-05)
 

--- a/ndk/src/configuration.rs
+++ b/ndk/src/configuration.rs
@@ -132,13 +132,17 @@ impl Configuration {
         unsafe { ffi::AConfiguration_match(self.ptr.as_ptr(), requested.ptr.as_ptr()) != 0 }
     }
 
-    /// Returns the country code. It will always be two letters.
-    pub fn country(&self) -> String {
-        let mut result = "  ".to_owned();
+    /// Returns the country code, as a [`String`] of two characters, if set
+    pub fn country(&self) -> Option<String> {
+        let mut chars = [0u8; 2];
         unsafe {
-            ffi::AConfiguration_getCountry(self.ptr.as_ptr(), result.as_mut_ptr() as *mut _);
+            ffi::AConfiguration_getCountry(self.ptr.as_ptr(), chars.as_mut_ptr() as *mut _);
         }
-        result
+        if chars[0] == 0 {
+            None
+        } else {
+            Some(std::str::from_utf8(chars.as_slice()).unwrap().to_owned())
+        }
     }
 
     /// Returns the screen density in dpi.
@@ -172,16 +176,16 @@ impl Configuration {
         }
     }
 
-    /// Returns the language, as a `String` of two characters, if a language is set
+    /// Returns the language, as a [`String`] of two characters, if set
     pub fn language(&self) -> Option<String> {
         let mut chars = [0u8; 2];
         unsafe {
-            ffi::AConfiguration_getLanguage(self.ptr.as_ptr(), chars[..].as_mut_ptr() as *mut _);
+            ffi::AConfiguration_getLanguage(self.ptr.as_ptr(), chars.as_mut_ptr() as *mut _);
         }
         if chars[0] == 0 {
             None
         } else {
-            Some(std::str::from_utf8(&chars[..]).unwrap().to_owned())
+            Some(std::str::from_utf8(chars.as_slice()).unwrap().to_owned())
         }
     }
 


### PR DESCRIPTION
Just like `fn language()` the country can be unset in a configuration, resulting in a string with two null bytes being returned to the caller.  As the caller might not necessarily be aware of this detail, provide them with a more explicit representation of "unset" like `language()`.
