### PR TITLE
ci/android_test: Remove possibly-cached APK from AVD before installing

### DIFF
--- a/.github/workflows/android_test.sh
+++ b/.github/workflows/android_test.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+# Make sure the package is removed since it may end up in the AVD cache. This causes
+# INSTALL_FAILED_UPDATE_INCOMPATIBLE errors when the debug keystore is regenerated,
+# as it is not stored/cached on the CI:
+# https://github.com/rust-windowing/android-ndk-rs/blob/240389f1e281f582b84a8049e2afaa8677d901c2/ndk-build/src/ndk.rs#L308-L332
+adb uninstall rust.example.hello_world || true
 
 if [ -z "$1" ];
 then


### PR DESCRIPTION
Make sure the package is removed since it may end up in the AVD cache.  This causes `INSTALL_FAILED_UPDATE_INCOMPATIBLE` errors when the debug keystore is regenerated, as it is not stored/cached on the CI: https://github.com/rust-windowing/android-ndk-rs/blob/240389f1e281f582b84a8049e2afaa8677d901c2/ndk-build/src/ndk.rs#L308-L332

CC @Gordon-F, perhaps you have an idea why this started happening all of a sudden?
