### PR TITLE
ndk-glue: Initialize ndk-context on 0.4 stable releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    branches: [master]
+    branches: [master, '*-stable']
     paths: "**/Cargo.toml"
 
 jobs:

--- a/ndk-examples/Cargo.toml
+++ b/ndk-examples/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 jni = "0.18.0"
 log = "0.4.14"
 ndk = { path = "../ndk", features = ["trace"] }
+ndk-context = "0.1.0"
 ndk-glue = { path = "../ndk-glue", features = ["logger"] }
 
 [[example]]

--- a/ndk-examples/examples/jni_audio.rs
+++ b/ndk-examples/examples/jni_audio.rs
@@ -7,9 +7,8 @@ const GET_DEVICES_OUTPUTS: jni::sys::jint = 2;
 
 fn enumerate_audio_devices() -> Result<(), Box<dyn std::error::Error>> {
     // Create a VM for executing Java calls
-    let native_activity = ndk_glue::native_activity();
-    let vm_ptr = native_activity.vm();
-    let vm = unsafe { jni::JavaVM::from_raw(vm_ptr) }?;
+    let ctx = ndk_context::android_context();
+    let vm = unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) }?;
     let env = vm.attach_current_thread()?;
 
     // Query the global Audio Service
@@ -18,7 +17,7 @@ fn enumerate_audio_devices() -> Result<(), Box<dyn std::error::Error>> {
 
     let audio_manager = env
         .call_method(
-            native_activity.activity(),
+            ctx.context().cast(),
             "getSystemService",
             // JNI type signature needs to be derived from the Java API
             // (ArgTys)ResultTy

--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.4.1 (2022-02-15)
+
+- Initialize `ndk-context` for cross-version access to the Java `VM` and Android `Context`.
+
 # 0.4.0 (2021-08-02)
 
 - Looper is now created before returning from `ANativeActivity_onCreate`, solving

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-glue"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Startup code for android binaries"
@@ -13,8 +13,9 @@ repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
 ndk = { path = "../ndk", version = "0.4.0" }
-ndk-sys = { path = "../ndk-sys", version = "0.2.1" }
+ndk-context = "0.1.0"
 ndk-macro = { path = "../ndk-macro", version = "0.2.0" }
+ndk-sys = { path = "../ndk-sys", version = "0.2.1" }
 lazy_static = "1.4.0"
 libc = "0.2.84"
 log = "0.4.14"

--- a/ndk-glue/src/lib.rs
+++ b/ndk-glue/src/lib.rs
@@ -55,6 +55,10 @@ lazy_static! {
 
 static mut NATIVE_ACTIVITY: Option<NativeActivity> = None;
 
+// Intentionally omitting this deprecation warning to not suddenly break peoples' CI builds
+// with a deprecation warning: especially since we don't have the full solution yet for applications
+// like winit that do need access to these globals.
+// #[deprecated = "Use `ndk_context::android_context().vm()` instead."]
 pub fn native_activity() -> &'static NativeActivity {
     unsafe { NATIVE_ACTIVITY.as_ref().unwrap() }
 }
@@ -154,6 +158,7 @@ pub unsafe fn init(
     callbacks.onLowMemory = Some(on_low_memory);
 
     let activity = NativeActivity::from_ptr(activity);
+    ndk_context::initialize_android_context(activity.vm().cast(), activity.activity().cast());
     NATIVE_ACTIVITY = Some(activity);
 
     let mut logpipe: [RawFd; 2] = Default::default();


### PR DESCRIPTION
In order to show that [#223] solves our problem ([#211]) with multiple ndk-glue versions in tree, all having their own `static` globals, backport the `ndk-context` initialization to `ndk-glue 0.4` so that everyone on this older crate can be compatible with other crates using the Java VM and/or Android Context.  These crates will need to migrate to `ndk-context` first though.

[#211]: https://github.com/rust-windowing/android-ndk-rs/issues/211
[#223]: https://github.com/rust-windowing/android-ndk-rs/pull/223
