### PR TITLE
gh/publish: Publish ndk-context crate directly from CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
           - { name: "ndk-sys", target: "armv7-linux-androideabi" }
           - { name: "ndk", target: "armv7-linux-androideabi" }
           - { name: "ndk-macro", target: "x86_64-unknown-linux-gnu" }
+          - { name: "ndk-context", target: "armv7-linux-androideabi" }
           - { name: "ndk-glue", target: "armv7-linux-androideabi" }
           - { name: "ndk-build", target: "x86_64-unknown-linux-gnu" }
           - { name: "cargo-apk", target: "x86_64-unknown-linux-gnu" }


### PR DESCRIPTION
This crate is missing in the list and has previously been published manually.

---

@dvc94ch I noticed this by seeing a different publisher on the ndk-context and ndk-glue crates, note that we can do publishing straight from `master` and there's no need to do it locally :)
