### PR TITLE
ndk-macro: Remove faulty crate name fallback in `fn crate_path()`

### DIFF
--- a/ndk-macro/src/helper.rs
+++ b/ndk-macro/src/helper.rs
@@ -52,16 +52,13 @@ pub fn crate_path(name: &str, overridden_path: &Option<Path>) -> Path {
     overridden_path.clone().unwrap_or_else(|| {
         Ident::new(
             // try to determine crate name from Cargo.toml
-            crate_name(name)
-                .ok()
+            match crate_name(name)
                 .as_ref()
-                .map(|name| match name {
-                    FoundCrate::Itself => "ndk_macro",
-                    FoundCrate::Name(n) => n.as_str(),
-                })
-                // or use default crate name
-                // (this may cause compilation error when crate is not found)
-                .unwrap_or_else(|| name),
+                .expect("Crate not found in `Cargo.toml`")
+            {
+                FoundCrate::Itself => "ndk_macro",
+                FoundCrate::Name(n) => n.as_str(),
+            },
             Span::call_site(),
         )
         .into()


### PR DESCRIPTION
`proc_macro_crate::crate_name` fails to find our `ndk-glue` crate when it sits inside `[target.'cfg(target_os = "android")'.dev-dependencies]` as shown in [RustAudio/cpal#641], with a fix pending in [bkchr/proc-macro-crate#15].  This function is only ever called with `"ndk-glue"` which is an invalid identifier and should have its dash replaced with an underscore to be valid.  However, since this fallback doesn't seem to have been hit before (we've never received reports of `` `"ndk-glue"` is not a valid identifier ``) it is safe and desired to enforce the crate name to reside in `Cargo.toml` and `proc-macro-crate` being able to find it.

[RustAudio/cpal#641]: https://github.com/RustAudio/cpal/runs/5203107529?check_suite_focus=true
[bkchr/proc-macro-crate#15]: https://github.com/bkchr/proc-macro-crate/pull/15
