### PR TITLE
Allow specifying manifest `package` property in `Cargo.toml`

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
   https://developer.android.com/distribute/best-practices/develop/target-sdk
+- Allow manifest `package` property to be provided in `Cargo.toml` ([#236](https://github.com/rust-windowing/android-ndk-rs/pull/236)).
 
 # 0.8.2 (2021-11-22)
 

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -27,6 +27,9 @@ Following configuration options are supported by `cargo apk` under `[package.met
 
 ```toml
 [package.metadata.android]
+# Specifies the package property of the manifest.
+package = "com.foo.bar"
+
 # Specifies the array of targets to build for.
 build_targets = [ "armv7-linux-androideabi", "aarch64-linux-android", "i686-linux-android", "x86_64-linux-android" ]
 

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -35,8 +35,6 @@ impl<'a> ApkBuilder<'a> {
             .join("apk");
 
         // Set default Android manifest values
-        assert!(manifest.android_manifest.package.is_empty());
-
         if manifest
             .android_manifest
             .version_name
@@ -93,14 +91,16 @@ impl<'a> ApkBuilder<'a> {
     }
 
     pub fn build(&self, artifact: &Artifact) -> Result<Apk, Error> {
-        let package_name = match artifact {
-            Artifact::Root(name) => format!("rust.{}", name.replace('-', "_")),
-            Artifact::Example(name) => format!("rust.example.{}", name.replace('-', "_")),
-        };
-
         // Set artifact specific manifest default values.
         let mut manifest = self.manifest.android_manifest.clone();
-        manifest.package = package_name;
+
+        if manifest.package.is_empty() {
+            manifest.package = match artifact {
+                Artifact::Root(name) => format!("rust.{}", name.replace('-', "_")),
+                Artifact::Example(name) => format!("rust.example.{}", name.replace('-', "_")),
+            };
+        }
+
         if manifest.application.label.is_empty() {
             manifest.application.label = artifact.name().to_string();
         }


### PR DESCRIPTION
Allows specifying `package` under the `[package.metadata.android]` section of `Cargo.toml`. This removes an `assert` that `package` is empty and only uses the previous forced value of `rust.<crate_name>` if `package.metadata.android.package` is empty.

cc: @MarijnS95 

Closes #234 