### PR TITLE
Fix provided libs hashset containing those missing on-device

### DIFF
--- a/ndk-build/src/readelf.rs
+++ b/ndk-build/src/readelf.rs
@@ -31,7 +31,9 @@ impl<'a> UnalignedApk<'a> {
         let mut provided = HashSet::new();
         for path in &android_search_paths {
             for lib in list_libs(path)? {
-                provided.insert(lib);
+                if lib != "libc++_shared.so" {
+                    provided.insert(lib);
+                }
             }
         }
 


### PR DESCRIPTION
A small bugfix to a bug introduced with #187, as `libc++_shared.so` is added into the `provided` hashset when crawling Android NDK search paths, which are assumed present on-device, but this particular case is neither on-device, nor ends up included as an artifact when bundling needed libraries.