### PR TITLE
ndk-build: Move default serialization of `MAIN` intent filter to `cargo-apk`

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Unreleased
 
-- Use `min_sdk_version` to select compiler target instead of `target_sdk_version` ([#197](https://github.com/rust-windowing/android-ndk-rs/pull/197)).
+- Use `min_sdk_version` to select compiler target instead of `target_sdk_version`. ([#197](https://github.com/rust-windowing/android-ndk-rs/pull/197))
   See https://developer.android.com/ndk/guides/sdk-versions#minsdkversion for more details.
 - Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
   https://developer.android.com/distribute/best-practices/develop/target-sdk
-- Allow manifest `package` property to be provided in `Cargo.toml` ([#236](https://github.com/rust-windowing/android-ndk-rs/pull/236)).
+- Allow manifest `package` property to be provided in `Cargo.toml`. ([#236](https://github.com/rust-windowing/android-ndk-rs/pull/236))
+- Add `MAIN` intent filter in `from_subcommand` instead of relying on a custom serialization function in `ndk-build`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
 
 # 0.8.2 (2021-11-22)
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
   https://developer.android.com/distribute/best-practices/develop/target-sdk
+- Remove default insertion of `MAIN` intent filter through a custom serialization function, this is better filled in by
+  the default setup in `cargo-apk`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
 
 # 0.4.3 (2021-11-22)
 

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -98,10 +98,9 @@ pub struct Activity {
     #[serde(default)]
     pub meta_data: Vec<MetaData>,
     /// If no `MAIN` action exists in any intent filter, a default `MAIN` filter is serialized.
-    #[serde(serialize_with = "serialize_intents")]
     #[serde(rename(serialize = "intent-filter"))]
     #[serde(default)]
-    pub intent_filter: Vec<IntentFilter>,
+    pub intent_filters: Vec<IntentFilter>,
 }
 
 impl Default for Activity {
@@ -113,34 +112,9 @@ impl Default for Activity {
             name: default_activity_name(),
             orientation: None,
             meta_data: Default::default(),
-            intent_filter: Default::default(),
+            intent_filters: Default::default(),
         }
     }
-}
-
-fn serialize_intents<S>(intent_filters: &[IntentFilter], serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    use serde::ser::SerializeSeq;
-
-    let mut seq = serializer.serialize_seq(None)?;
-    for intent_filter in intent_filters {
-        seq.serialize_element(intent_filter)?;
-    }
-
-    // Check if `intent_filters` contains a `MAIN` action. If not, add a default filter.
-    if intent_filters
-        .iter()
-        .all(|i| i.actions.iter().all(|f| f != "android.intent.action.MAIN"))
-    {
-        seq.serialize_element(&IntentFilter {
-            actions: vec!["android.intent.action.MAIN".to_string()],
-            categories: vec!["android.intent.category.LAUNCHER".to_string()],
-            data: vec![],
-        })?;
-    }
-    seq.end()
 }
 
 /// Android [intent filter element](https://developer.android.com/guide/topics/manifest/intent-filter-element).


### PR DESCRIPTION
The other two manual `serialize_with` functions have a very clear purpose of making the datastructure easier to work with, by turning a vector of strings into a more verbose XML element with the string as `name` field.

No such case with `intent_filter`, which needs no special serialization treatment but instead performs actual business logic to insert more elements based on what the caller wishes to serialize.  This sort of logic is better moved to `cargo-apk` where a toml-parsed manifest is similarly enriched with sensible defaults to make Android development as accessible and out-of-the-box as possible.

---

As discussed in #204, this seems to be the most sensible place (or should we get something that mimicks `serde(default)` so that it's present earlier on? - might be more tricky to adequately set `exported=true` by default then).
