### PR TITLE
cargo-apk: Export native activity by default on Android S and up

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -7,6 +7,7 @@
   https://developer.android.com/distribute/best-practices/develop/target-sdk
 - Allow manifest `package` property to be provided in `Cargo.toml`. ([#236](https://github.com/rust-windowing/android-ndk-rs/pull/236))
 - Add `MAIN` intent filter in `from_subcommand` instead of relying on a custom serialization function in `ndk-build`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
+- Export the sole `NativeActivity` (through `android:exported="true"`) to allow it to be started by default if targeting Android S or higher. ([#242](https://github.com/rust-windowing/android-ndk-rs/pull/242))
 
 # 0.8.2 (2021-11-22)
 

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -126,6 +126,11 @@ launch_mode = "singleTop"
 # Defaults to "unspecified".
 orientation = "landscape"
 
+# See https://developer.android.com/guide/topics/manifest/activity-element#exported
+#
+# Defaults to "unspecified".
+exported = "true"
+
 # See https://developer.android.com/guide/topics/manifest/meta-data-element
 #
 # Note: there can be several .meta_data entries.

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -128,7 +128,7 @@ orientation = "landscape"
 
 # See https://developer.android.com/guide/topics/manifest/activity-element#exported
 #
-# Defaults to "unspecified".
+# Unset by default, or "true" when targeting Android >= 31 (S and up).
 exported = "true"
 
 # See https://developer.android.com/guide/topics/manifest/meta-data-element

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -53,7 +53,7 @@ impl<'a> ApkBuilder<'a> {
             panic!("version_code should not be set in TOML");
         }
 
-        manifest
+        let target_sdk_version = *manifest
             .android_manifest
             .sdk
             .target_sdk_version
@@ -78,6 +78,13 @@ impl<'a> ApkBuilder<'a> {
                 categories: vec!["android.intent.category.LAUNCHER".to_string()],
                 data: vec![],
             });
+        }
+
+        // Export the sole Rust activity on Android S and up, if the user didn't explicitly do so.
+        // Without this, apps won't start on S+.
+        // https://developer.android.com/about/versions/12/behavior-changes-12#exported
+        if target_sdk_version >= 31 {
+            activity.exported.get_or_insert(true);
         }
 
         Ok(Self {

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -5,6 +5,7 @@
   https://developer.android.com/distribute/best-practices/develop/target-sdk
 - Remove default insertion of `MAIN` intent filter through a custom serialization function, this is better filled in by
   the default setup in `cargo-apk`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
+- Add `android:exported` attribute to the manifest's `Activity` element. ([#242](https://github.com/rust-windowing/android-ndk-rs/pull/242))
 
 # 0.4.3 (2021-11-22)
 

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -93,6 +93,8 @@ pub struct Activity {
     pub name: String,
     #[serde(rename(serialize = "android:screenOrientation"))]
     pub orientation: Option<String>,
+    #[serde(rename(serialize = "android:exported"))]
+    pub exported: Option<bool>,
 
     #[serde(rename(serialize = "meta-data"))]
     #[serde(default)]
@@ -111,6 +113,7 @@ impl Default for Activity {
             launch_mode: None,
             name: default_activity_name(),
             orientation: None,
+            exported: None,
             meta_data: Default::default(),
             intent_filters: Default::default(),
         }


### PR DESCRIPTION
Depends on #241

Subsumes #204

Similar to how we help the user with a default `MAIN` intent filter to launch the sole `NativeActivity` in their application (and setting a few other sensible defaults), we should also set Android's new `android:exported` attribute to `true` if they're targeting Android S (SDK 31) or higher.

Without this set to `true` the Rust app is not allowed to be started externally (by ie. a launcher or `adb`) on Android S+, and with only a single `Activity` currently supported by `ndk-build` it is unlikely (but not impossible, see shared user IDs etc), that there are other means to start it internally.

https://developer.android.com/guide/topics/manifest/activity-element#exported
