### PR TITLE
ndk: Remove on_success closure argument from `fn from_status()`

### DIFF
--- a/ndk/src/media/error.rs
+++ b/ndk/src/media/error.rs
@@ -42,13 +42,10 @@ pub enum NdkMediaError {
 }
 
 impl NdkMediaError {
-    pub(crate) fn from_status<T>(
-        status: ffi::media_status_t,
-        on_success: impl FnOnce() -> T,
-    ) -> Result<T> {
+    pub(crate) fn from_status(status: ffi::media_status_t) -> Result<()> {
         use MediaErrorResult::*;
         let result = match status {
-            ffi::media_status_t_AMEDIA_OK => return Ok(on_success()),
+            ffi::media_status_t_AMEDIA_OK => return Ok(()),
             ffi::media_status_t_AMEDIACODEC_ERROR_INSUFFICIENT_RESOURCE => {
                 CodecErrorInsufficientResource
             }

--- a/ndk/src/media/image_reader.rs
+++ b/ndk/src/media/image_reader.rs
@@ -124,7 +124,7 @@ impl ImageReader {
             onImageAvailable: Some(on_image_available),
         };
         let status = unsafe { ffi::AImageReader_setImageListener(self.as_ptr(), &mut listener) };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     #[cfg(feature = "hardware_buffer")]
@@ -152,7 +152,7 @@ impl ImageReader {
         };
         let status =
             unsafe { ffi::AImageReader_setBufferRemovedListener(self.as_ptr(), &mut listener) };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     pub fn get_window(&self) -> Result<NativeWindow> {
@@ -272,7 +272,7 @@ impl Image {
             )
         };
 
-        NdkMediaError::from_status(status, || unsafe {
+        NdkMediaError::from_status(status).map(|()| unsafe {
             std::slice::from_raw_parts(result_ptr.assume_init(), result_len.assume_init() as _)
         })
     }

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -177,7 +177,7 @@ impl MediaFormat {
 impl Drop for MediaFormat {
     fn drop(&mut self) {
         let status = unsafe { ffi::AMediaFormat_delete(self.as_ptr()) };
-        NdkMediaError::from_status(status, || ()).unwrap();
+        NdkMediaError::from_status(status).unwrap();
     }
 }
 
@@ -235,7 +235,7 @@ impl MediaCodec {
                 },
             )
         };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     #[cfg(feature = "api-level-26")]
@@ -277,7 +277,7 @@ impl MediaCodec {
                 index: result as ffi::size_t,
             }))
         } else {
-            NdkMediaError::from_status(result as ffi::media_status_t, || None)
+            NdkMediaError::from_status(result as ffi::media_status_t).map(|()| None)
         }
     }
 
@@ -305,13 +305,13 @@ impl MediaCodec {
                 info,
             }))
         } else {
-            NdkMediaError::from_status(result as ffi::media_status_t, || None)
+            NdkMediaError::from_status(result as ffi::media_status_t).map(|()| None)
         }
     }
 
     pub fn flush(&self) -> Result<()> {
         let status = unsafe { ffi::AMediaCodec_flush(self.as_ptr()) };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     #[cfg(feature = "api-level-28")]
@@ -367,14 +367,14 @@ impl MediaCodec {
                 flags,
             )
         };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     pub fn release_output_buffer(&self, buffer: OutputBuffer, render: bool) -> Result<()> {
         let status = unsafe {
             ffi::AMediaCodec_releaseOutputBuffer(self.as_ptr(), buffer.index as ffi::size_t, render)
         };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     pub fn release_output_buffer_at_time(
@@ -389,49 +389,49 @@ impl MediaCodec {
                 timestamp_ns,
             )
         };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     #[cfg(feature = "api-level-26")]
     pub fn set_input_surface(&self, surface: NativeWindow) -> Result<()> {
         let status =
             unsafe { ffi::AMediaCodec_setInputSurface(self.as_ptr(), surface.ptr().as_ptr()) };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     pub fn set_output_surface(&self, surface: NativeWindow) -> Result<()> {
         let status =
             unsafe { ffi::AMediaCodec_setOutputSurface(self.as_ptr(), surface.ptr().as_ptr()) };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     #[cfg(feature = "api-level-26")]
     pub fn set_parameters(&self, params: MediaFormat) -> Result<()> {
         let status = unsafe { ffi::AMediaCodec_setParameters(self.as_ptr(), params.as_ptr()) };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     #[cfg(feature = "api-level-26")]
     pub fn set_signal_end_of_input_stream(&self) -> Result<()> {
         let status = unsafe { ffi::AMediaCodec_signalEndOfInputStream(self.as_ptr()) };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     pub fn start(&self) -> Result<()> {
         let status = unsafe { ffi::AMediaCodec_start(self.as_ptr()) };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 
     pub fn stop(&self) -> Result<()> {
         let status = unsafe { ffi::AMediaCodec_stop(self.as_ptr()) };
-        NdkMediaError::from_status(status, || ())
+        NdkMediaError::from_status(status)
     }
 }
 
 impl Drop for MediaCodec {
     fn drop(&mut self) {
         let status = unsafe { ffi::AMediaCodec_delete(self.as_ptr()) };
-        NdkMediaError::from_status(status, || ()).unwrap();
+        NdkMediaError::from_status(status).unwrap();
     }
 }
 

--- a/ndk/src/media/mod.rs
+++ b/ndk/src/media/mod.rs
@@ -15,7 +15,7 @@ pub type Result<T, E = NdkMediaError> = std::result::Result<T, E>;
 fn construct<T>(with_ptr: impl FnOnce(*mut T) -> ffi::camera_status_t) -> Result<T> {
     let mut result = MaybeUninit::uninit();
     let status = with_ptr(result.as_mut_ptr());
-    NdkMediaError::from_status(status, || unsafe { result.assume_init() })
+    NdkMediaError::from_status(status).map(|()| unsafe { result.assume_init() })
 }
 
 fn construct_never_null<T>(


### PR DESCRIPTION
By far the most calls of this function pass a closure that returns the void type.  All these default calls can be simplified by always returning the void type in `Result<()>` from `fn from_status()`, and use the standard `Resuld::map(|()| ...)` to provide a different ok-value in the few cases an actual return value is desired.
