### PR TITLE
media/media_codec: Replace `construct_never_null` and infallible `unwrap()` pattern with something more sensible

### DIFF
--- a/ndk/src/media/mod.rs
+++ b/ndk/src/media/mod.rs
@@ -29,3 +29,12 @@ fn construct_never_null<T>(
     };
     Ok(non_null)
 }
+
+fn get_never_null<T>(get_ptr: impl FnOnce() -> *mut T) -> NonNull<T> {
+    let result = get_ptr();
+    if cfg!(debug_assertions) {
+        NonNull::new(result).expect("result should never be null")
+    } else {
+        unsafe { NonNull::new_unchecked(result) }
+    }
+}


### PR DESCRIPTION
These functions return a pointer directly instead of an error code with the pointer as argument, making them unsuitable for use with `construct_never_null`.  Because there is no error code, returning a manual success value still requires an infallible `unwrap()` call to unpack the `Result`.

Replace this with a new helper function that does not unnecessarily wrap the resulting pointer in a `Result` when there is no result code to base this off, and match the signature to a function that returns the pointer directly.

At the same time reduce the size of some `unsafe {}` blocks to wrap just what is unsafe.
