### PR TITLE
cargo-apk: Upgrade to `cargo-subcommand 0.7.0` for `[env]` support

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `MAIN` intent filter in `from_subcommand` instead of relying on a custom serialization function in `ndk-build`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
 - Export the sole `NativeActivity` (through `android:exported="true"`) to allow it to be started by default if targeting Android S or higher. ([#242](https://github.com/rust-windowing/android-ndk-rs/pull/242))
 - `cargo-apk` version can now be queried through `cargo apk version`
+- Environment variables from `.cargo/config.toml`'s `[env]` section are now propagated to the process environment. ([#249](https://github.com/rust-windowing/android-ndk-rs/pull/249))
 
 # 0.8.2 (2021-11-22)
 

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
 anyhow = "1.0.38"
-cargo-subcommand = "0.5.0"
+cargo-subcommand = "0.7.0"
 dunce = "1.0.1"
 env_logger = "0.8.2"
 log = "0.4.14"


### PR DESCRIPTION
Environment variables can be set and override the process environment through `.cargo/config.toml`'s `[env]` section: https://doc.rust-lang.org/cargo/reference/config.html#env

These config variables have specific precedence rules with regards to overriding the environment set in the process, and can optionally represent paths relative to the parent of the containing `.cargo/` folder.  The entire handling of these variables is implemented in https://github.com/dvc94ch/cargo-subcommand/pull/12 and https://github.com/dvc94ch/cargo-subcommand/pull/16 which immediately populate the process environment with these variables when `Subcommand::new()` is called by `cargo-apk`.
