### PR TITLE
media_codec: Uphold non-`null` guarantees in some erratic scenarios

### DIFF
--- a/ndk/src/media/mod.rs
+++ b/ndk/src/media/mod.rs
@@ -30,11 +30,12 @@ fn construct_never_null<T>(
     Ok(non_null)
 }
 
-fn get_never_null<T>(get_ptr: impl FnOnce() -> *mut T) -> NonNull<T> {
+/// Function is not expected to ever return `null`, but this
+/// cannot be validated through the Android documentation.
+///
+/// As such this function always asserts on `null` values,
+/// even when `cfg!(debug_assertions)` is disabled.
+fn get_unlikely_to_be_null<T>(get_ptr: impl FnOnce() -> *mut T) -> NonNull<T> {
     let result = get_ptr();
-    if cfg!(debug_assertions) {
-        NonNull::new(result).expect("result should never be null")
-    } else {
-        unsafe { NonNull::new_unchecked(result) }
-    }
+    NonNull::new(result).expect("result should never be null")
 }


### PR DESCRIPTION
CC @zarik5, this is the last of things I think we need for `media_codec` to be stable enough?

The Android documentation does not comment on when functions could possibly return `null`, and while discussion in [#248] finds these unlikely enough to be communicated back to the user there is no 100% guarantee and the resulting pointers should as such always be checked (either at all, or also when `cfg!(debug_assertions)` happens to be disabled).

Note that this `NonNull::new(..).unwrap()` pattern is found in many other places in the `ndk`.

[#248]: https://github.com/rust-windowing/android-ndk-rs/pull/248
