### PR TITLE
cargo-apk: Use `ndk-gdb` from the NDK root directory instead of expecting it in $PATH

### DIFF
--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -241,7 +241,9 @@ impl<'a> ApkBuilder<'a> {
             jni_dir.join("Android.mk"),
             format!("APP_ABI=\"{}\"\nTARGET_OUT=\"\"\n", abi.android_abi()),
         )?;
-        Command::new("ndk-gdb").current_dir(target_dir).status()?;
+        Command::new(self.ndk.ndk().join("ndk-gdb"))
+            .current_dir(target_dir)
+            .status()?;
         Ok(())
     }
 


### PR DESCRIPTION
Hardly anyone has the root directory of the NDK in their `$PATH` or installed globally.  Thus, just like any other tool, invoke it from the detected and selected NDK directly.
