### PR TITLE
cargo-apk,ndk-build: Move `ndk-gdb` setup to `ndk-build` and support Windows

### DIFF
--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -4,7 +4,8 @@
 - Add `adb` device serial parameter to `detect_abi()` and `Apk::{install,start}()`. ([#329](https://github.com/rust-windowing/android-ndk-rs/pull/329))
 - Fix missing `.exe` extension for `adb` on Windows inside `detect_abi()`. ([#339](https://github.com/rust-windowing/android-ndk-rs/pull/339))
 - `start()` now returns the PID of the started app process (useful for passing to `adb logcat --pid`). ([#331](https://github.com/rust-windowing/android-ndk-rs/pull/331))
-- Add `ndk_gdb()` function to acquire `ndk-gdb` script path with the appropriate extension across platforms. ([#330](https://github.com/rust-windowing/android-ndk-rs/pull/330))
+- Inherit `ndk_gdb()` function from `cargo-apk` with the appropriate script extension across platforms. ([#330](https://github.com/rust-windowing/android-ndk-rs/pull/330), [#258](https://github.com/rust-windowing/android-ndk-rs/pull/258))
+
 
 # 0.7.0 (2022-07-05)
 


### PR DESCRIPTION
Depends on #257

Just a draft for now as I haven't really tested this on Windows yet - but the missing `.cmd` is obvious enough, and this command is probably useful to expose from the `ndk-build` library anyway.
