### PR TITLE
ndk-glue,ndk-context: Remove `AndroidContext` when activity is destroyed

### DIFF
--- a/ndk-context/CHANGELOG.md
+++ b/ndk-context/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `release_android_context()` function to remove `AndroidContext` when activity is destroyed. (#263)
+
 # 0.1.0 (2022-02-14)
 
 - Initial release! 🎉

--- a/ndk-context/src/lib.rs
+++ b/ndk-context/src/lib.rs
@@ -86,3 +86,15 @@ pub unsafe fn initialize_android_context(java_vm: *mut c_void, context_jobject: 
     });
     assert!(previous.is_none());
 }
+
+/// Removes the [`AndroidContext`]. It is released by [__ndk-glue__](https://crates.io/crates/ndk-glue)
+/// when the activity is finished and destroyed.
+///
+/// # Safety
+///
+/// This function must only be called after [`initialize_android_context()`],
+/// when the activity is subsequently destroyed according to Android.
+pub unsafe fn release_android_context() {
+    let previous = ANDROID_CONTEXT.take();
+    assert!(previous.is_some());
+}

--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Call `ndk_context::release_android_context()` function to remove `AndroidContext` when activity is destroyed. (#263)
+
 # 0.6.1 (2022-02-14)
 
 - Initialize `ndk-context` for cross-version access to the Java `VM` and Android `Context`.

--- a/ndk-glue/src/lib.rs
+++ b/ndk-glue/src/lib.rs
@@ -251,6 +251,7 @@ unsafe extern "C" fn on_stop(activity: *mut ANativeActivity) {
 
 unsafe extern "C" fn on_destroy(activity: *mut ANativeActivity) {
     wake(activity, Event::Destroy);
+    ndk_context::release_android_context();
 }
 
 unsafe extern "C" fn on_configuration_changed(activity: *mut ANativeActivity) {


### PR DESCRIPTION
Fixes #261

Android runs multiple activities of the same app inside the same process, and shutting down followed by starting a `NativeActivity` inside the same process (that's been kept alive by another activity) causes the `static ANDROID_CONTEXT` in `ndk-context` to retain its value.  This value should be cleared to prevent leaking possibly invalid pointers and ultimately crashing in `assert!(previous.is_none());` when a native activity is restarted within that process.

Note that this still doesn't allow for multiple `NativeActivity` instances to be started concurrently.
