### PR TITLE
Release ndk-context-0.1.1, ndk-glue-0.6.2

### DIFF
--- a/ndk-context/CHANGELOG.md
+++ b/ndk-context/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.1.1 (2022-04-19)
+
 - Add `release_android_context()` function to remove `AndroidContext` when activity is destroyed. (#263)
 
 # 0.1.0 (2022-02-14)

--- a/ndk-context/Cargo.toml
+++ b/ndk-context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-context"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The Rust Windowing contributors"]
 edition = "2021"
 description = "Handles for accessing Android APIs"

--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.6.2 (2022-04-19)
+
 - Call `ndk_context::release_android_context()` function to remove `AndroidContext` when activity is destroyed. (#263)
 
 # 0.6.1 (2022-02-14)
@@ -10,6 +12,10 @@
 
 - **Breaking:** Update to `ndk-sys 0.3.0` and `ndk 0.6.0`.
 
+# 0.5.2 (2022-04-19)
+
+- Call `ndk_context::release_android_context()` function to remove `AndroidContext` when activity is destroyed. (#263)
+
 # 0.5.1 (2022-02-15)
 
 - Initialize `ndk-context` for cross-version access to the Java `VM` and Android `Context`.
@@ -18,6 +24,10 @@
 
 - Document when to lock and unlock the window/input queue when certain events are received.
 - **Breaking:** Update to `ndk 0.5.0` and `ndk-macros 0.3.0`.
+
+# 0.4.2 (2022-04-19)
+
+- Call `ndk_context::release_android_context()` function to remove `AndroidContext` when activity is destroyed. (#263)
 
 # 0.4.1 (2022-02-15)
 

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-glue"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Startup code for android binaries"
@@ -13,7 +13,7 @@ repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
 ndk = { path = "../ndk", version = "0.6.0" }
-ndk-context = { path = "../ndk-context", version = "0.1.0" }
+ndk-context = { path = "../ndk-context", version = "0.1.1" }
 ndk-macro = { path = "../ndk-macro", version = "0.3.0" }
 ndk-sys = { path = "../ndk-sys", version = "0.3.0" }
 lazy_static = "1.4.0"


### PR DESCRIPTION
And prepare the changelogs for ndk-glue-0.4.2 and ndk-glue-0.5.2, whose backports will be processed in the respective stable branches.
