### PR TITLE
cargo-apk: Reimplement NDK r23 `-lgcc` workaround using `RUSTFLAGS`

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Reimplement NDK r23 `-lgcc` workaround using `RUSTFLAGS`, to apply to transitive `cdylib` compilations (#270)
+
 # 0.9.0 (2022-05-07)
 
 - **Breaking:** Use `min_sdk_version` to select compiler target instead of `target_sdk_version`. ([#197](https://github.com/rust-windowing/android-ndk-rs/pull/197))


### PR DESCRIPTION
Fixes #265, CC @mercesa

Any flags passed directly to `cargo rustc` will only be passed _to the final compiler invocation_.  However `cdylib` library targets in transitive (dependency) crates will still be built (despite not being used in the final binary, that's what `rlib`s are for), but our NDK r23 workaround flags will not reach these compiler invocations rendering b912a6b ("cargo-apk: Work around missing libgcc on NDK r23 with linker script (#189)") ineffective.

[The same page] that documents this discrepancy suggests to resort to `RUSTFLAGS` if arguments are intended for all compiler invocations, which is our intended use-case and unblocks builds with transitive `cdylib` dependencies such as `hyper` in [#265].

[The same page]: https://doc.rust-lang.org/cargo/commands/cargo-rustc.html#description
[#265]: https://github.com/rust-windowing/android-ndk-rs/issues/265
