### PR TITLE
ndk: Implement `HasRawWindowHandle` directly on `NativeWindow`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Unreleased
 
-- hardware_buffer: Make `HardwareBuffer::as_ptr()` public for interop with Vulkan.
+- hardware_buffer: Make `HardwareBuffer::as_ptr()` public for interop with Vulkan. (#213)
 - **Breaking:** `Configuration::country()` now returns `None` when the country is unset (akin to `Configuration::language()`)
 - Add `MediaCodec` and `MediaFormat` bindings. (#216)
 - **Breaking:** Upgrade to [`ndk-sys 0.4.0`](../ndk-sys/CHANGELOG.md#040-TODO-YET-UNRELEASED) and use new `enum` newtype wrappers. (#245)
 - native_window: Use `release`/`acquire` for `Drop` and `Clone` respectively. (#207)
 - **Breaking:** audio: Rename from `aaudio` to `audio` and drop `A` prefix. (#273)
+- Implement `HasRawWindowHandle` directly on `NativeWindow` (#274)
 
 # 0.6.0 (2022-01-05)
 

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -35,6 +35,7 @@ test = ["ffi/test", "jni", "jni-glue", "all"]
 bitflags = "1.2.1"
 jni-sys = "0.3.0"
 num_enum = "0.5.1"
+raw-window-handle = "0.4"
 thiserror = "1.0.23"
 
 [dependencies.jni]

--- a/ndk/src/native_window.rs
+++ b/ndk/src/native_window.rs
@@ -1,7 +1,8 @@
 //! Bindings for [`ffi::ANativeWindow`]
 
 use jni_sys::{jobject, JNIEnv};
-use std::ptr::NonNull;
+use raw_window_handle::{AndroidNdkHandle, HasRawWindowHandle, RawWindowHandle};
+use std::{ffi::c_void, ptr::NonNull};
 
 #[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NativeWindow {
@@ -23,6 +24,14 @@ impl Clone for NativeWindow {
             ffi::ANativeWindow_acquire(self.ptr.as_ptr());
             Self { ptr: self.ptr }
         }
+    }
+}
+
+unsafe impl HasRawWindowHandle for NativeWindow {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        let mut handle = AndroidNdkHandle::empty();
+        handle.a_native_window = self.ptr.as_ptr() as *mut c_void;
+        RawWindowHandle::AndroidNdk(handle)
     }
 }
 


### PR DESCRIPTION
Crates wrapping the NDK (winit and others), and `NativeWindow` in particular have to implement `HasRawWindowHandle` on their own wrapper types, yet the `ndk` should also implement this trait on the `NativeWindow` type directly for them to reuse.  Or more importantly, when the "raw" `ndk` crate is used directly.
