### PR TITLE
native_window: Add `format()` getter and `set_buffers_geometry()` setter

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Breaking:** audio: Rename from `aaudio` to `audio` and drop `A` prefix. (#273)
 - Implement `HasRawWindowHandle` directly on `NativeWindow`. (#274)
 - **Breaking:** native_activity: Replace `CStr` return types with `Path`. (#279)
+- native_window: Add `format()` getter and `set_buffers_geometry()` setter. (#276)
 
 # 0.6.0 (2022-01-05)
 

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "hardware_buffer")]
+
+pub use super::hardware_buffer_format::HardwareBufferFormat;
 use jni_sys::{jobject, JNIEnv};
-use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::{
     convert::TryInto, mem::MaybeUninit, ops::Deref, os::raw::c_void, os::unix::io::RawFd,
     ptr::NonNull,
@@ -77,26 +78,6 @@ impl HardwareBufferUsage {
         Self(ffi::AHardwareBuffer_UsageFlags_AHARDWAREBUFFER_USAGE_VENDOR_18);
     pub const VENDOR_19: Self =
         Self(ffi::AHardwareBuffer_UsageFlags_AHARDWAREBUFFER_USAGE_VENDOR_19);
-}
-
-#[repr(u32)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
-#[allow(non_camel_case_types)]
-pub enum HardwareBufferFormat {
-    R8G8B8A8_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM.0,
-    R8G8B8X8_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM.0,
-    R8G8B8_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM.0,
-    R5G6B5_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM.0,
-    R16G16B16A16_FLOAT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT.0,
-    R10G10B10A2_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM.0,
-    BLOB = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_BLOB.0,
-    D16_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_D16_UNORM.0,
-    D24_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_D24_UNORM.0,
-    D24_UNORM_S8_UINT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_D24_UNORM_S8_UINT.0,
-    D32_FLOAT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_D32_FLOAT.0,
-    D32_FLOAT_S8_UINT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_D32_FLOAT_S8_UINT.0,
-    S8_UINT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_S8_UINT.0,
-    Y8Cb8Cr8_420 = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420.0,
 }
 
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]

--- a/ndk/src/hardware_buffer_format.rs
+++ b/ndk/src/hardware_buffer_format.rs
@@ -1,0 +1,34 @@
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
+#[allow(non_camel_case_types)]
+pub enum HardwareBufferFormat {
+    /// Matches deprecated [`ffi::ANativeWindow_LegacyFormat_WINDOW_FORMAT_RGBA_8888`].
+    R8G8B8A8_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM.0,
+    /// Matches deprecated [`ffi::ANativeWindow_LegacyFormat_WINDOW_FORMAT_RGBX_8888`].
+    R8G8B8X8_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM.0,
+    #[cfg(feature = "api-level-26")]
+    R8G8B8_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM.0,
+    /// Matches deprecated [`ffi::ANativeWindow_LegacyFormat_WINDOW_FORMAT_RGB_565`].
+    R5G6B5_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM.0,
+    R16G16B16A16_FLOAT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT.0,
+    #[cfg(feature = "api-level-26")]
+    R10G10B10A2_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM.0,
+    #[cfg(feature = "api-level-26")]
+    BLOB = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_BLOB.0,
+    #[cfg(feature = "api-level-26")]
+    D16_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_D16_UNORM.0,
+    #[cfg(feature = "api-level-26")]
+    D24_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_D24_UNORM.0,
+    #[cfg(feature = "api-level-26")]
+    D24_UNORM_S8_UINT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_D24_UNORM_S8_UINT.0,
+    #[cfg(feature = "api-level-26")]
+    D32_FLOAT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_D32_FLOAT.0,
+    #[cfg(feature = "api-level-26")]
+    D32_FLOAT_S8_UINT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_D32_FLOAT_S8_UINT.0,
+    #[cfg(feature = "api-level-26")]
+    S8_UINT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_S8_UINT.0,
+    #[cfg(feature = "api-level-26")]
+    Y8Cb8Cr8_420 = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420.0,
+}

--- a/ndk/src/lib.rs
+++ b/ndk/src/lib.rs
@@ -16,15 +16,15 @@
 #![warn(missing_debug_implementations, trivial_casts)]
 
 pub mod asset;
+pub mod audio;
 pub mod bitmap;
 pub mod configuration;
 pub mod event;
+pub mod hardware_buffer;
+pub mod hardware_buffer_format;
 pub mod input_queue;
 pub mod looper;
+pub mod media;
 pub mod native_activity;
 pub mod native_window;
-
-pub mod audio;
-pub mod hardware_buffer;
-pub mod media;
 pub mod trace;

--- a/ndk/src/native_activity.rs
+++ b/ndk/src/native_activity.rs
@@ -182,11 +182,3 @@ impl NativeActivity {
         unsafe { ffi::ANativeActivity_setWindowFormat(self.ptr.as_ptr(), format.into()) }
     }*/
 }
-
-/*#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
-#[repr(u32)]
-pub enum WindowFormat {
-    Rgb565 = ffi::ANativeWindow_LegacyFormat_WINDOW_FORMAT_RGB_565,
-    Rgba8888 = ffi::ANativeWindow_LegacyFormat_WINDOW_FORMAT_RGBA_8888,
-    Rgbx8888 = ffi::ANativeWindow_LegacyFormat_WINDOW_FORMAT_RGBX_8888,
-}*/


### PR DESCRIPTION
Android's `NativeWindow` allow querying the format through `ANativeWindow_getFormat` and setting it through `ANativeWindow_setBuffersGeometry` together with the dimensions to use for the buffer.
