### PR TITLE
ndk/native_activity: Replace `CStr` return types with `Path`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -6,7 +6,8 @@
 - **Breaking:** Upgrade to [`ndk-sys 0.4.0`](../ndk-sys/CHANGELOG.md#040-TODO-YET-UNRELEASED) and use new `enum` newtype wrappers. (#245)
 - native_window: Use `release`/`acquire` for `Drop` and `Clone` respectively. (#207)
 - **Breaking:** audio: Rename from `aaudio` to `audio` and drop `A` prefix. (#273)
-- Implement `HasRawWindowHandle` directly on `NativeWindow` (#274)
+- Implement `HasRawWindowHandle` directly on `NativeWindow`. (#274)
+- **Breaking:** native_activity: Replace `CStr` return types with `Path`. (#279)
 
 # 0.6.0 (2022-01-05)
 

--- a/ndk/src/native_activity.rs
+++ b/ndk/src/native_activity.rs
@@ -3,10 +3,12 @@
 //! See also [the NDK
 //! docs](https://developer.android.com/ndk/reference/struct/a-native-activity.html)
 
-//use num_enum::{IntoPrimitive, TryFromPrimitive};
-use std::ffi::CStr;
-use std::os::raw::c_void;
-use std::ptr::NonNull;
+use std::{
+    ffi::{CStr, OsStr},
+    os::{raw::c_void, unix::prelude::OsStrExt},
+    path::Path,
+    ptr::NonNull,
+};
 
 /// An `ANativeActivity *`
 ///
@@ -40,7 +42,7 @@ impl NativeActivity {
 /// Methods that relate to fields of the struct itself
 ///
 /// The relevant NDK docs can be found
-/// [here.](https://developer.android.com/ndk/reference/struct/a-native-activity)
+/// [here](https://developer.android.com/ndk/reference/struct/a-native-activity).
 impl NativeActivity {
     /// The platform's SDK version code
     pub fn sdk_version(&self) -> i32 {
@@ -48,13 +50,15 @@ impl NativeActivity {
     }
 
     /// Path to this application's internal data directory
-    pub fn internal_data_path(&self) -> &CStr {
-        unsafe { CStr::from_ptr(self.ptr.as_ref().internalDataPath) }
+    pub fn internal_data_path(&self) -> &Path {
+        OsStr::from_bytes(unsafe { CStr::from_ptr(self.ptr.as_ref().internalDataPath) }.to_bytes())
+            .as_ref()
     }
 
     /// Path to this application's external (removable, mountable) data directory
-    pub fn external_data_path(&self) -> &CStr {
-        unsafe { CStr::from_ptr(self.ptr.as_ref().externalDataPath) }
+    pub fn external_data_path(&self) -> &Path {
+        OsStr::from_bytes(unsafe { CStr::from_ptr(self.ptr.as_ref().externalDataPath) }.to_bytes())
+            .as_ref()
     }
 
     /// This app's asset manager, which can be used to access assets from the `.apk` file.
@@ -123,15 +127,15 @@ impl NativeActivity {
     ///
     /// # Safety
     /// Only available as of Honeycomb (Android 3.0+, API level 11+)
-    pub unsafe fn obb_path(&self) -> &CStr {
-        CStr::from_ptr(self.ptr.as_ref().obbPath)
+    pub unsafe fn obb_path(&self) -> &Path {
+        OsStr::from_bytes(CStr::from_ptr(self.ptr.as_ref().obbPath).to_bytes()).as_ref()
     }
 }
 
 /// Methods that relate to `ANativeActivity_*` functions.
 ///
 /// The relevant NDK docs can be found
-/// [here.](https://developer.android.com/ndk/reference/group/native-activity)
+/// [here](https://developer.android.com/ndk/reference/group/native-activity).
 impl NativeActivity {
     /// Sends a destroy event to the activity and stops it.
     pub fn finish(&self) {


### PR DESCRIPTION
These functions return a path, which is slightly more ergonomic to handle when actually returned as an `std::path::Path` type instead of a `CStr`.

---

Unsure if this is actually the correct handling for going from a `CStr` -> `OsStr` (`Path`), but it seems to make sense / be correct since I don't think Unix requires paths to be UTF-8 (and go through ie. `&str`).
