### PR TITLE
ndk-glue: Switch to `parking_lot` for `map`pable and `Send`able lock guards

### DIFF
--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **Breaking:** Provide a `LockReadGuard` newtype around `NativeWindow`/`InputQueue` to hide the underlying lock implementation. (#288)
+- **Breaking:** Transpose `LockReadGuard<Option<T>>` into `Option<LockReadGuard<T>>` to only necessitate an `Option` unpack/`unwrap()` once. (#282)
 
 # 0.6.2 (2022-04-19)
 

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -12,14 +12,15 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [dependencies]
+android_logger = { version = "0.11", optional = true }
+libc = "0.2.84"
+log = "0.4.14"
 ndk = { path = "../ndk", version = "0.6.0" }
 ndk-context = { path = "../ndk-context", version = "0.1.1" }
 ndk-macro = { path = "../ndk-macro", version = "0.3.0" }
 ndk-sys = { path = "../ndk-sys", version = "0.3.0" }
 once_cell = "1"
-libc = "0.2.84"
-log = "0.4.14"
-android_logger = { version = "0.11", optional = true }
+parking_lot = "0.12"
 
 [features]
 default = []


### PR DESCRIPTION
Depends on #282

It has come up previously that the `native_window()` function is easier to use if we could transpose a `LockGuard<Option<>>` into an `Option<LockGuard<>>`.  After all, as soon as you have the lock you only need to check the `Option<>` value once and are thereafter guaranteed that its value won't change, until the lock is given up.

At the same time `parking_lot` has a `send_guard` feature which allows moving a lock guard to another thread (as long as `deadlock_detection` is disabled); a use case for this recently came up [in glutin] where the `NativeWindow` handle lock should be stored with a GL context so that our `fn on_window_destroyed()` callback doesn't return until after the `Surface` created on it is removed from the context and destroyed.  Glutin forces this context to be `Send`, and a lock guard already allows `Sync` if `NativeWindow` is `Sync` (which it is).

[in glutin]: https://github.com/rust-windowing/glutin/pull/1411#discussion_r883677680
