### PR TITLE
ndk-build,cargo-apk: Disable `aapt` compression for the `dev` profile

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-- Move NDK r23 `-lgcc` workaround to `ndk-build::cargo::cargo_ndk`, to also apply to our `cargo apk --` invocations. ([#286](https://github.com/rust-windowing/android-ndk-rs/pull/286))
+- Move NDK r23 `-lgcc` workaround to `ndk_build::cargo::cargo_ndk()`, to also apply to our `cargo apk --` invocations. ([#286](https://github.com/rust-windowing/android-ndk-rs/pull/286))
+- Disable `aapt` compression for the [(default) `dev` profile](https://doc.rust-lang.org/cargo/reference/profiles.html). ([#283](https://github.com/rust-windowing/android-ndk-rs/pull/283))
 
 # 0.9.1 (2022-05-12)
 

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -167,6 +167,7 @@ impl<'a> ApkBuilder<'a> {
             assets,
             resources,
             manifest,
+            disable_aapt_compression: self.cmd.profile() == &Profile::Dev,
         };
         let apk = config.create_apk()?;
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-- **Breaking:** Provide NDK r23 `-lgcc` workaround in `cargo_ndk` function, now requiring `target_dir` as argument. ([#286](https://github.com/rust-windowing/android-ndk-rs/pull/286))
+- **Breaking:** Provide NDK r23 `-lgcc` workaround in `cargo_ndk()` function, now requiring `target_dir` as argument. ([#286](https://github.com/rust-windowing/android-ndk-rs/pull/286))
+- **Breaking:** Add `disable_aapt_compression` field to `ApkConfig` to disable `aapt` compression. ([#283](https://github.com/rust-windowing/android-ndk-rs/pull/283))
 
 # 0.5.0 (2022-05-07)
 


### PR DESCRIPTION
As suggested in #153:

Compressing multi-megabyte libraries in `aapt` is a singlethreaded process that takes many (tens of) seconds, for no apparent gain.  It slows down the iterative development process significantly whereas there's no concern for `adb` transferring larger `apk`s over even USB 2.0 (which is still much faster than the bandwidth `aapt` provides for compression) nor typically any space constraints on development devices.
