### PR TITLE
ndk-glue: Replace ancient `lazy_static` crate with `once_cell`

### DIFF
--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -16,7 +16,7 @@ ndk = { path = "../ndk", version = "0.6.0" }
 ndk-context = { path = "../ndk-context", version = "0.1.1" }
 ndk-macro = { path = "../ndk-macro", version = "0.3.0" }
 ndk-sys = { path = "../ndk-sys", version = "0.3.0" }
-lazy_static = "1.4.0"
+once_cell = "1"
 libc = "0.2.84"
 log = "0.4.14"
 android_logger = { version = "0.10.1", optional = true }


### PR DESCRIPTION
Piggybacking on the [motivation in winit]: `lazy_static!` is a macro whereas `once_cell` achieves the same using generics.  Its implementation has also been [proposed for inclusion in `std`], making it easier for us to switch to a standardized version if/when that happens.  The author of that winit PR is making this change to many more crates, slowly turning the scales in favour of `once_cell` in our dependency tree too.

Furthermore `lazy_static` hasn't published any updates for 3 years, and the new syntax is closer for dropping this wrapping completely when the necessary constructors become `const` (i.e. switching to `parking_lot` will give us a [`const fn new()` on `RwLock`]) or this feature lands in stable `std`.

[motivation in winit]: https://github.com/rust-windowing/winit/pull/2313
[proposed for inclusion in `std`]: https://github.com/rust-lang/rust/issues/74465
[`const fn new()` on `RwLock`]: https://docs.rs/lock_api/latest/lock_api/struct.RwLock.html#method.new
