### PR TITLE
cargo-apk: Append `--target` to blanket `cargo apk --` calls when not provided

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Move NDK r23 `-lgcc` workaround to `ndk_build::cargo::cargo_ndk()`, to also apply to our `cargo apk --` invocations. ([#286](https://github.com/rust-windowing/android-ndk-rs/pull/286))
 - Disable `aapt` compression for the [(default) `dev` profile](https://doc.rust-lang.org/cargo/reference/profiles.html). ([#283](https://github.com/rust-windowing/android-ndk-rs/pull/283))
+- Append `--target` to blanket `cargo apk --` calls when not provided by the user. ([#287](https://github.com/rust-windowing/android-ndk-rs/pull/287))
 
 # 0.9.1 (2022-05-12)
 

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -98,7 +98,6 @@ impl<'a> ApkBuilder<'a> {
 
     pub fn check(&self) -> Result<(), Error> {
         for target in &self.build_targets {
-            let triple = target.rust_triple();
             let mut cargo = cargo_ndk(
                 &self.ndk,
                 *target,
@@ -107,6 +106,7 @@ impl<'a> ApkBuilder<'a> {
             )?;
             cargo.arg("check");
             if self.cmd.target().is_none() {
+                let triple = target.rust_triple();
                 cargo.arg("--target").arg(triple);
             }
             cargo.args(self.cmd.args());
@@ -247,6 +247,12 @@ impl<'a> ApkBuilder<'a> {
                 self.cmd.target_dir(),
             )?;
             cargo.args(self.cmd.args());
+
+            if self.cmd.target().is_none() {
+                let triple = target.rust_triple();
+                cargo.arg("--target").arg(triple);
+            }
+
             if !cargo.status()?.success() {
                 return Err(NdkError::CmdFailed(cargo).into());
             }


### PR DESCRIPTION
Depends on #286, #283

When the user doesn't provide a `--target` we default the triple to the currently connected device over `adb`, or otherwise fall back to `aarch64`.

While this triple is always used to determine what NDK environment to provide, it's never added to the arguments passed after `--`; for example a `cargo apk -- test --no-run` will try to build tests for the host unless explicitly called with `--target`.

---

I can't currently think of any command that one might want to run under `cargo apk --` with an NDK environment, but without support for `--target`. If there is, that's a valid argument to not pass this flag (but perhaps clearly document it, maybe even warn about it if we don't find `--target` in the call?).
