### PR TITLE
ndk/input_queue: Replace `InputQueueError` with `std::io::Error` and add missing docs

### DIFF
--- a/ndk-examples/examples/looper.rs
+++ b/ndk-examples/examples/looper.rs
@@ -118,7 +118,7 @@ fn main() {
                         let input_queue = input_queue.as_ref().expect("Input queue not attached");
                         assert!(input_queue.has_events().unwrap());
                         // Consume as many events as possible
-                        while let Some(event) = input_queue.get_event() {
+                        while let Some(event) = input_queue.get_event().unwrap() {
                             // Pass the event by a possible IME (Input Method Editor, ie. an open keyboard) first
                             if let Some(event) = input_queue.pre_dispatch(event) {
                                 info!("Input event {:?}", event);

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -13,6 +13,7 @@
 - native_activity: Add `set_window_flags()` to change window behavior. (#278)
 - Add `SurfaceTexture` bindings. (#267)
 - Improve library and structure documentation, linking back to the NDK docs more rigorously. (#290)
+- **Breaking:** input_queue: `InputQueue::{get_event,has_events}()` now return a `Result` with `std::io::Error`; `InputQueueError` has been removed. (#292)
 
 # 0.6.0 (2022-01-05)
 


### PR DESCRIPTION
These `AInputQueue` functions all return [standard `errno.h` error codes] which can and should be communicated back to the user instead of appearing as some opaque magic struct.

In addition import the NDK documentation for all these functions and make the scope of `unsafe` blocks smaller.

[standard `errno.h` error codes]: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/jni/android_view_InputQueue.cpp;l=112;drc=7b3193e1e86ab5c0fcb784cb8616864045dd2515
