### PR TITLE
Enable `doc_cfg` and `doc_auto_cfg` for all `[features]` crates on https://docs.rs

### DIFF
--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -27,6 +27,7 @@ test = ["ndk/test", "ndk-sys/test"]
 logger = ["android_logger", "ndk-macro/logger"]
 
 [package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",

--- a/ndk-glue/src/lib.rs
+++ b/ndk-glue/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 use log::Level;
 use ndk::input_queue::InputQueue;
 use ndk::looper::{FdEvent, ForeignLooper, ThreadLooper};

--- a/ndk-macro/Cargo.toml
+++ b/ndk-macro/Cargo.toml
@@ -24,3 +24,6 @@ darling = "0.13"
 [features]
 default = []
 logger = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/ndk-macro/src/lib.rs
+++ b/ndk-macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 use darling::FromMeta;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, ItemFn};

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -21,6 +21,7 @@ bitmap = []
 media = []
 
 [package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",

--- a/ndk-sys/src/lib.rs
+++ b/ndk-sys/src/lib.rs
@@ -14,6 +14,7 @@
 #![allow(deref_nullptr)]
 // Test setup lints
 #![cfg_attr(test, allow(dead_code))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use jni_sys::*;
 

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -53,6 +53,7 @@ version = "0.3.0"
 
 [package.metadata.docs.rs]
 features = ["jni", "jni-glue", "all"]
+rustdoc-args = ["--cfg", "docsrs"]
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",

--- a/ndk/src/lib.rs
+++ b/ndk/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! [Android NDK]: https://developer.android.com/ndk/reference
 #![warn(missing_debug_implementations, trivial_casts)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod asset;
 pub mod audio;


### PR DESCRIPTION
The documentation currently doesn't expose what features a user needs to enable before certain functionality becomes available, requiring them to look at the sourcecode as we don't really provide much documentation or guideance towards this.

That's totally fine because it is a job for `rustdoc`, one that it performs very well when the experimental `doc_cfg` feature is enabled, and specifically `doc_auto_cfg` to not have to manually re-specify every `#[cfg(<guard>)]` within a `#[cfg_attr(docs_rs, doc(cfg(<guard>)))]`.

docs.rs builds on `nightly` which makes this possible, and docs can be built with the `docsrs` cfg enabled locally to see the result, e.g.:

    RUSTDOCFLAGS="-Dwarnings --cfg docsrs" cargo +nightly doc --no-deps --workspace --target aarch64-linux-android --all-features --document-private-items --open
