### PR TITLE
ndk/input_queue: Remove `Result` wrapping from `has_events()`

### DIFF
--- a/ndk-examples/examples/looper.rs
+++ b/ndk-examples/examples/looper.rs
@@ -116,7 +116,7 @@ fn main() {
                     ndk_glue::NDK_GLUE_LOOPER_INPUT_QUEUE_IDENT => {
                         let input_queue = ndk_glue::input_queue();
                         let input_queue = input_queue.as_ref().expect("Input queue not attached");
-                        assert!(input_queue.has_events().unwrap());
+                        assert!(input_queue.has_events());
                         // Consume as many events as possible
                         while let Some(event) = input_queue.get_event().unwrap() {
                             // Pass the event by a possible IME (Input Method Editor, ie. an open keyboard) first

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -13,7 +13,8 @@
 - native_activity: Add `set_window_flags()` to change window behavior. (#278)
 - Add `SurfaceTexture` bindings. (#267)
 - Improve library and structure documentation, linking back to the NDK docs more rigorously. (#290)
-- **Breaking:** input_queue: `InputQueue::{get_event,has_events}()` now return a `Result` with `std::io::Error`; `InputQueueError` has been removed. (#292)
+- **Breaking:** input_queue: `get_event()` now returns a `Result` with `std::io::Error`; `InputQueueError` has been removed. (#292)
+- **Breaking:** input_queue: `has_events()` now returns a `bool` directly without being wrapped in `Result`. (#294)
 - **Breaking:** Update `jni` crate (used in public API) from `0.18` to `0.19`. (#300)
 
 # 0.6.0 (2022-01-05)

--- a/ndk/src/input_queue.rs
+++ b/ndk/src/input_queue.rs
@@ -59,11 +59,10 @@ impl InputQueue {
     }
 
     /// Returns [`true`] if there are one or more events available in the input queue.
-    pub fn has_events(&self) -> Result<bool> {
+    pub fn has_events(&self) -> bool {
         match unsafe { ffi::AInputQueue_hasEvents(self.ptr.as_ptr()) } {
-            0 => Ok(false),
-            1 => Ok(true),
-            r if r < 0 => Err(Error::from_raw_os_error(-r)),
+            0 => false,
+            1 => true,
             r => unreachable!("AInputQueue_hasEvents returned non-boolean {}", r),
         }
     }


### PR DESCRIPTION
After having blindly retained error handling in #292, it turns out the underlying [`InputQueue::hasEvents()` implementation] doesn't ever return an error nor does the documentation state that this is possible.

As such, mimic what we're already doing in `fn pre_dispatch()` and panic if the value doesn't represent a `bool`.

[`InputQueue::hasEvents()` implementation]: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/jni/android_view_InputQueue.cpp;l=88-91;drc=5497dd365e9135805636a40267cb98e2e2b78ee6
