### PR TITLE
ndk: Replace `HardwareBufferError` with `std::io::Error` through new helper conversion function

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Improve library and structure documentation, linking back to the NDK docs more rigorously. (#290)
 - **Breaking:** input_queue: `get_event()` now returns a `Result` with `std::io::Error`; `InputQueueError` has been removed. (#292)
 - **Breaking:** input_queue: `has_events()` now returns a `bool` directly without being wrapped in `Result`. (#294)
+- **Breaking:** hardware_buffer: `HardwareBufferError` has been removed and replaced with `std::io::Error` in return types. (#295)
 - **Breaking:** Update `jni` crate (used in public API) from `0.18` to `0.19`. (#300)
 
 # 0.6.0 (2022-01-05)

--- a/ndk/src/lib.rs
+++ b/ndk/src/lib.rs
@@ -19,3 +19,4 @@ pub mod native_activity;
 pub mod native_window;
 pub mod surface_texture;
 pub mod trace;
+mod utils;

--- a/ndk/src/native_window.rs
+++ b/ndk/src/native_window.rs
@@ -2,10 +2,12 @@
 //!
 //! [`ANativeWindow`]: https://developer.android.com/ndk/reference/group/a-native-window#anativewindow
 
+use crate::utils::status_to_io_result;
+
 pub use super::hardware_buffer_format::HardwareBufferFormat;
 use jni_sys::{jobject, JNIEnv};
 use raw_window_handle::{AndroidNdkHandle, HasRawWindowHandle, RawWindowHandle};
-use std::{convert::TryFrom, ffi::c_void, ptr::NonNull};
+use std::{convert::TryFrom, ffi::c_void, io::Result, ptr::NonNull};
 
 // [`NativeWindow`] represents the producer end of an image queue
 ///
@@ -94,16 +96,12 @@ impl NativeWindow {
         width: i32,
         height: i32,
         format: Option<HardwareBufferFormat>,
-    ) -> Result<(), i32> {
+    ) -> Result<()> {
         let format: u32 = format.map_or(0, |f| f.into());
-        let r = unsafe {
+        let status = unsafe {
             ffi::ANativeWindow_setBuffersGeometry(self.ptr.as_ptr(), width, height, format as i32)
         };
-        if r == 0 {
-            Ok(())
-        } else {
-            Err(r)
-        }
+        status_to_io_result(status, ())
     }
 
     /// Return the [`NativeWindow`] associated with a JNI [`android.view.Surface`] pointer.

--- a/ndk/src/surface_texture.rs
+++ b/ndk/src/surface_texture.rs
@@ -6,14 +6,9 @@
 //! [`ASurfaceTexture`]: https://developer.android.com/ndk/reference/group/surface-texture
 #![cfg(feature = "api-level-28")]
 
-use crate::native_window::NativeWindow;
+use crate::{native_window::NativeWindow, utils::status_to_io_result};
 use jni_sys::{jobject, JNIEnv};
-use std::{
-    convert::TryInto,
-    io::{Error, Result},
-    ptr::NonNull,
-    time::Duration,
-};
+use std::{convert::TryInto, io::Result, ptr::NonNull, time::Duration};
 
 /// An opaque type to manage [`android.graphics.SurfaceTexture`] from native code
 ///
@@ -88,14 +83,8 @@ impl SurfaceTexture {
     /// contexts. Note, however, that the image contents are only accessible from one OpenGL ES
     /// context at a time.
     pub fn attach_to_gl_context(&self, tex_name: u32) -> Result<()> {
-        match unsafe { ffi::ASurfaceTexture_attachToGLContext(self.ptr.as_ptr(), tex_name) } {
-            0 => Ok(()),
-            r if r < 0 => Err(Error::from_raw_os_error(-r)),
-            r => unreachable!(
-                "ASurfaceTexture_attachToGLContext returned positive integer {}",
-                r
-            ),
-        }
+        let status = unsafe { ffi::ASurfaceTexture_attachToGLContext(self.ptr.as_ptr(), tex_name) };
+        status_to_io_result(status, ())
     }
 
     /// Detach the [`SurfaceTexture`] from the OpenGL ES context that owns the OpenGL ES texture
@@ -110,14 +99,8 @@ impl SurfaceTexture {
     /// contexts. Note, however, that the image contents are only accessible from one OpenGL ES
     /// context at a time.
     pub fn detach_from_gl_context(&self) -> Result<()> {
-        match unsafe { ffi::ASurfaceTexture_detachFromGLContext(self.ptr.as_ptr()) } {
-            0 => Ok(()),
-            r if r < 0 => Err(Error::from_raw_os_error(-r)),
-            r => unreachable!(
-                "ASurfaceTexture_detachFromGLContext returned positive integer {}",
-                r
-            ),
-        }
+        let status = unsafe { ffi::ASurfaceTexture_detachFromGLContext(self.ptr.as_ptr()) };
+        status_to_io_result(status, ())
     }
 
     /// Retrieve the 4x4 texture coordinate transform matrix associated with the texture image set
@@ -170,13 +153,7 @@ impl SurfaceTexture {
     /// calling thread. It will implicitly bind its texture to the `GL_TEXTURE_EXTERNAL_OES`
     /// texture target.
     pub fn update_tex_image(&self) -> Result<()> {
-        match unsafe { ffi::ASurfaceTexture_updateTexImage(self.ptr.as_ptr()) } {
-            0 => Ok(()),
-            r if r < 0 => Err(Error::from_raw_os_error(-r)),
-            r => unreachable!(
-                "ASurfaceTexture_updateTexImage returned positive integer {}",
-                r
-            ),
-        }
+        let status = unsafe { ffi::ASurfaceTexture_updateTexImage(self.ptr.as_ptr()) };
+        status_to_io_result(status, ())
     }
 }

--- a/ndk/src/utils.rs
+++ b/ndk/src/utils.rs
@@ -1,0 +1,14 @@
+//! Internal utilities
+use std::io::{Error, Result};
+
+/// Turns standard `<errno.h>` status codes - typically rewrapped by Android's [`Errors.h`] - into
+/// Rust's [`std::io::Error`].
+///
+/// [`Errors.h`]: https://cs.android.com/android/platform/superproject/+/master:system/core/libutils/include/utils/Errors.h
+pub(crate) fn status_to_io_result<T>(status: i32, value: T) -> Result<T> {
+    match status {
+        0 => Ok(value),
+        r if r < 0 => Err(Error::from_raw_os_error(-r)),
+        r => unreachable!("Status is positive integer {}", r),
+    }
+}


### PR DESCRIPTION
Depends on #294

These `AHardwareBuffer` functions all return [standard `errno.h` error codes] which can be communicated back to the user in ergonomic form instead of appearing as a newtyped struct holding a "meaningless" `i32`.

Perform the same conversion to just `NativeWindow::set_buffers_geometry` which also returns `errno.h` codes: this change is small enough to not warrant _yet another_ PR, as we've already changed the exact same for `InputQueueError` in [#292].  (Note that this is intentionally omitted from the changelog since `set_buffers_geometry()` is only making its debut in the upcoming release, this change isn't breaking).

This pattern is now prevalent across the codebase (`hardware_buffer`, `surface_texture`, and `native_window` all use it), warranting the new `status_to_io_result()` helper function to be introduced in an also-new `utils.rs` module.

[standard `errno.h` error codes]: https://cs.android.com/android/platform/superproject/+/master:frameworks/native/libs/nativewindow/AHardwareBuffer.cpp;drc=4120991d92a0265ce480672f704612556328057e
[#292]: https://github.com/rust-windowing/android-ndk-rs/pull/292
