### PR TITLE
ndk-build: Switch NDK r23 -lgcc workaround to `CARGO_ENCODED_RUSTFLAGS` env var for paths with spaces

### DIFF
--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Allow NDK r23 `-lgcc` workaround to work for target directories containing spaces. ([#298](https://github.com/rust-windowing/android-ndk-rs/pull/298))
+
 # 0.6.0 (2022-06-11)
 
 - **Breaking:** Provide NDK r23 `-lgcc` workaround in `cargo_ndk()` function, now requiring `target_dir` as argument. ([#286](https://github.com/rust-windowing/android-ndk-rs/pull/286))

--- a/ndk-build/src/cargo.rs
+++ b/ndk-build/src/cargo.rs
@@ -41,18 +41,21 @@ pub fn cargo_ndk(
         // forwarded to the final compiler invocation rendering our workaround ineffective.
         // The cargo page documenting this discrepancy (https://doc.rust-lang.org/cargo/commands/cargo-rustc.html)
         // suggests to resort to RUSTFLAGS, which are updated below:
-        let mut rustflags = match std::env::var("RUSTFLAGS") {
+        let mut rustflags = match std::env::var("CARGO_ENCODED_RUSTFLAGS") {
             Ok(val) => val,
             Err(std::env::VarError::NotPresent) => "".to_string(),
             Err(std::env::VarError::NotUnicode(_)) => {
                 panic!("RUSTFLAGS environment variable contains non-unicode characters")
             }
         };
-        rustflags += " -L ";
+        if !rustflags.is_empty() {
+            rustflags.push('\x1f');
+        }
+        rustflags += "-L\x1f";
         rustflags += cargo_apk_link_dir
             .to_str()
             .expect("Target dir must be valid UTF-8");
-        cargo.env("RUSTFLAGS", rustflags);
+        cargo.env("CARGO_ENCODED_RUSTFLAGS", rustflags);
     }
 
     Ok(cargo)


### PR DESCRIPTION
On Windows user paths usually include people's full name, with a space. If they have their Rust project somewhere in their user profile `cargo` fails to parse the workaround path:

    process didn't exit successfully: `rustc - --crate-name ___ --print=file-names -L '"C:\Users\Bla' 'Haj\Desktop\Breda\target\cargo-apk-temp-extra-link-libraries"' ... (exit code: 1)

As per the [documentation for `RUSTFLAGS`] its contents are split by a very simple `.split(" ")` algorithm without caring for quotation delimiters or escape characters. To retain backwards compatibility this has been implemented in a new environment variable named `CARGO_ENCODED_RUSTFLAGS`, which separates by ASCII Unit Separators (`0x1f`) instead.

[documentation for `RUSTFLAGS`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html