### PR TITLE
cargo-apk: Configure APK signing keystore location through manifest

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Allow configuration of alternate debug keystore location; require keystore location for release builds. ([#299](https://github.com/rust-windowing/android-ndk-rs/pull/299))
+
 # 0.9.2 (2022-06-11)
 
 - Move NDK r23 `-lgcc` workaround to `ndk_build::cargo::cargo_ndk()`, to also apply to our `cargo apk --` invocations. ([#286](https://github.com/rust-windowing/android-ndk-rs/pull/286))

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -50,6 +50,13 @@ apk_name = "myapp"
 # according to the specified build_targets.
 runtime_libs = "path/to/libs_folder"
 
+# Defaults to `$HOME/.android/debug.keystore` for the `dev` profile. Will ONLY generate a new
+# debug.keystore if this file does NOT exist.
+# A keystore path is always required on the `release` profile.
+[package.metadata.android.signing.<profile>]
+path = "$HOME/.android/debug.keystore"
+keystore_password = "android"
+
 # See https://developer.android.com/guide/topics/manifest/uses-sdk-element
 #
 # Defaults to a `min_sdk_version` of 23 and `target_sdk_version` of 30 (or lower if the detected NDK doesn't support this).

--- a/cargo-apk/src/error.rs
+++ b/cargo-apk/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     Ndk(#[from] NdkError),
     #[error(transparent)]
     Io(#[from] IoError),
+    #[error("Configure a release keystore via `[package.metadata.android.signing.{0}]`")]
+    MissingReleaseKey(String),
 }
 
 impl Error {

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -314,7 +314,7 @@ impl Ndk {
                 .arg("-keystore")
                 .arg(&path)
                 .arg("-storepass")
-                .arg("android")
+                .arg(&password)
                 .arg("-alias")
                 .arg("androiddebugkey")
                 .arg("-keypass")


### PR DESCRIPTION
All builds currently use a fixed debug keystore.  This is cumbersome on machines where `keytool` isn't installed, and odd for `release` builds.

To make sharing debug APKs more consistent across developers this allows them to check in their `debug.keystore` in a repository and reuse it for everyone.

At the same time there's no sensible default-debug keystore for release builds; these require explicit configuration through the manifest (yet nothing withholds the user from passing their debug keystore here, if they so desire - but at least it's explicit).
