### PR TITLE
ndk-build,cargo-apk: Rename `intent_filters` back to `intent_filter`

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
+# 0.9.3 (2022-07-05)
+
 - Allow configuration of alternate debug keystore location; require keystore location for release builds. ([#299](https://github.com/rust-windowing/android-ndk-rs/pull/299))
+- **Breaking:** Rename `Activity::intent_filters` back to `Activity::intent_filter`. ([#305](https://github.com/rust-windowing/android-ndk-rs/pull/305))
 
 # 0.9.2 (2022-06-11)
 

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-apk"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Helps cargo build APKs"
@@ -16,7 +16,7 @@ cargo-subcommand = "0.7"
 dunce = "1"
 env_logger = "0.9"
 log = "0.4"
-ndk-build = { path = "../ndk-build", version = "0.6.0" }
+ndk-build = { path = "../ndk-build", version = "0.7.0" }
 serde = "1"
 thiserror = "1.0.31"
 toml = "0.5"

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -69,11 +69,11 @@ impl<'a> ApkBuilder<'a> {
 
         // Add a default `MAIN` action to launch the activity, if the user didn't supply it by hand.
         if activity
-            .intent_filters
+            .intent_filter
             .iter()
             .all(|i| i.actions.iter().all(|f| f != "android.intent.action.MAIN"))
         {
-            activity.intent_filters.push(IntentFilter {
+            activity.intent_filter.push(IntentFilter {
                 actions: vec!["android.intent.action.MAIN".to_string()],
                 categories: vec!["android.intent.category.LAUNCHER".to_string()],
                 data: vec![],

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
-- Allow NDK r23 `-lgcc` workaround to work for target directories containing spaces. ([#298](https://github.com/rust-windowing/android-ndk-rs/pull/298))
+# 0.7.0 (2022-07-05)
+
+- Fix NDK r23 `-lgcc` workaround for target directories containing spaces. ([#298](https://github.com/rust-windowing/android-ndk-rs/pull/298))
 - Invoke `clang` directly instead of through the NDK's wrapper scripts. ([#306](https://github.com/rust-windowing/android-ndk-rs/pull/306))
+- **Breaking:** Rename `Activity::intent_filters` back to `Activity::intent_filter`. ([#305](https://github.com/rust-windowing/android-ndk-rs/pull/305))
 
 # 0.6.0 (2022-06-11)
 

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-build"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Utilities for building Android binaries"

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -106,10 +106,10 @@ pub struct Activity {
     #[serde(rename(serialize = "meta-data"))]
     #[serde(default)]
     pub meta_data: Vec<MetaData>,
-    /// If no `MAIN` action exists in any intent filter, a default `MAIN` filter is serialized.
+    /// If no `MAIN` action exists in any intent filter, a default `MAIN` filter is serialized by `cargo-apk`.
     #[serde(rename(serialize = "intent-filter"))]
     #[serde(default)]
-    pub intent_filters: Vec<IntentFilter>,
+    pub intent_filter: Vec<IntentFilter>,
 }
 
 impl Default for Activity {
@@ -122,7 +122,7 @@ impl Default for Activity {
             orientation: None,
             exported: None,
             meta_data: Default::default(),
-            intent_filters: Default::default(),
+            intent_filter: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Fixes #304, CC @hoodad

We commonly name vectors of items with their singular form so that they read nicer in TOML and XML (i.e. `[[intent_filter]]` adds a single entry to that list, and gets serialized as a single `<intent-filter>` XML element) and this matches Android's `intent-filter` naming too.

This change in a6f3e13 ("ndk-build: Move default serialization of `MAIN` intent filter to `cargo-apk` (#241)") was made purely with `Vec` in mind, but breaks existing manifest parsing nor was anticipated to be a breaking change in this area as the README still carries `intent_filter` instead of `intent_filters` in its `Cargo.toml` metadata reference.

---

I want to try landing this without yet-another breaking release for `ndk-build`: can we do that by yanking the previous releases? We don't need a breaking release for `cargo-apk` either way, but it may be nice to yank their older releases too.
