### PR TITLE
ndk-build: Invoke `clang` directly instead of through wrapper scripts

### DIFF
--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Allow NDK r23 `-lgcc` workaround to work for target directories containing spaces. ([#298](https://github.com/rust-windowing/android-ndk-rs/pull/298))
+- Invoke `clang` directly instead of through the NDK's wrapper scripts. ([#306](https://github.com/rust-windowing/android-ndk-rs/pull/306))
 
 # 0.6.0 (2022-06-11)
 

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -116,7 +116,7 @@ impl<'a> UnalignedApk<'a> {
         search_paths: &[&Path],
     ) -> Result<(), NdkError> {
         let abi_dir = path.join(target.android_abi());
-        for entry in fs::read_dir(&abi_dir).map_err(|e| NdkError::IoPathError(e, abi_dir))? {
+        for entry in fs::read_dir(&abi_dir).map_err(|e| NdkError::IoPathError(abi_dir, e))? {
             let entry = entry?;
             let path = entry.path();
             if path.extension() == Some(OsStr::new("so")) {

--- a/ndk-build/src/error.rs
+++ b/ndk-build/src/error.rs
@@ -39,8 +39,8 @@ pub enum NdkError {
     UnsupportedHost(String),
     #[error(transparent)]
     Io(#[from] IoError),
-    #[error("{0:?}: `{1}`")]
-    IoPathError(#[source] IoError, PathBuf),
+    #[error("IoError on `{0:?}`: {1}")]
+    IoPathError(PathBuf, #[source] IoError),
     #[error("Invalid semver")]
     InvalidSemver,
     #[error("Command `{}` had a non-zero exit code.", format!("{:?}", .0).replace('"', ""))]

--- a/ndk-build/src/lib.rs
+++ b/ndk-build/src/lib.rs
@@ -1,21 +1,21 @@
 macro_rules! bin {
-    ($bin:expr) => {{
-        #[cfg(not(target_os = "windows"))]
-        let bin = $bin;
-        #[cfg(target_os = "windows")]
-        let bin = concat!($bin, ".exe");
-        bin
-    }};
+    ($bin:expr) => {
+        if cfg!(target_os = "windows") {
+            concat!($bin, ".exe")
+        } else {
+            $bin
+        }
+    };
 }
 
 macro_rules! bat {
-    ($bat:expr) => {{
-        #[cfg(not(target_os = "windows"))]
-        let bat = $bat;
-        #[cfg(target_os = "windows")]
-        let bat = concat!($bat, ".bat");
-        bat
-    }};
+    ($bat:expr) => {
+        if cfg!(target_os = "windows") {
+            concat!($bat, ".bat")
+        } else {
+            $bat
+        }
+    };
 }
 
 pub mod apk;

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -228,21 +228,21 @@ impl Ndk {
         Ok(toolchain_dir)
     }
 
-    pub fn clang(&self, target: Target, platform: u32) -> Result<(PathBuf, PathBuf), NdkError> {
-        #[cfg(target_os = "windows")]
-        let ext = ".cmd";
-        #[cfg(not(target_os = "windows"))]
-        let ext = "";
+    pub fn clang(&self) -> Result<(PathBuf, PathBuf), NdkError> {
+        let ext = if cfg!(target_os = "windows") {
+            "exe"
+        } else {
+            ""
+        };
 
-        let bin_name = format!("{}{}-clang", target.ndk_llvm_triple(), platform);
         let bin_path = self.toolchain_dir()?.join("bin");
 
-        let clang = bin_path.join(format!("{}{}", &bin_name, ext));
+        let clang = bin_path.join("clang").with_extension(ext);
         if !clang.exists() {
             return Err(NdkError::PathNotFound(clang));
         }
 
-        let clang_pp = bin_path.join(format!("{}++{}", &bin_name, ext));
+        let clang_pp = bin_path.join("clang++").with_extension(ext);
         if !clang_pp.exists() {
             return Err(NdkError::PathNotFound(clang_pp));
         }
@@ -251,10 +251,11 @@ impl Ndk {
     }
 
     pub fn toolchain_bin(&self, name: &str, target: Target) -> Result<PathBuf, NdkError> {
-        #[cfg(target_os = "windows")]
-        let ext = ".exe";
-        #[cfg(not(target_os = "windows"))]
-        let ext = "";
+        let ext = if cfg!(target_os = "windows") {
+            ".exe"
+        } else {
+            ""
+        };
 
         let toolchain_path = self.toolchain_dir()?.join("bin");
 


### PR DESCRIPTION
The NDK's wrapper scripts for `clang`/`clang++` currently only, and will only ever pass `--target` to the compiler.  That is something we can do ourselves, especially now that we're already updating `RUSTFLAGS` anyway.

[Upstream even clarified] that it is recommended to pass `--target` yourself instead of incurring extra overhead while going through the wrapper scripts (especially costly on Windows), further guaranteeing that we won't miss out on any flags possibly being added to the wrapper scripts in the future.

[Upstream even clarified]: https://r.android.com/2134712
