### PR TITLE
media_codec: `NativeWindow` can be optional in `fn configure()`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **Breaking:** `MediaCodec::configure` now accepts `Option<&NartiveWindow>` instead of `&NativeWindow`, as per https://developer.android.com/reference/android/media/MediaCodec#configure(android.media.MediaFormat,%20android.view.Surface,%20android.media.MediaCrypto,%20int)
 - hardware_buffer: Make `HardwareBuffer::as_ptr()` public for interop with Vulkan. (#213)
 - **Breaking:** `Configuration::country()` now returns `None` when the country is unset (akin to `Configuration::language()`)
 - Add `MediaCodec` and `MediaFormat` bindings. (#216)

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Unreleased
 
-- **Breaking:** `MediaCodec::configure` now accepts `Option<&NartiveWindow>` instead of `&NativeWindow`, as per https://developer.android.com/reference/android/media/MediaCodec#configure(android.media.MediaFormat,%20android.view.Surface,%20android.media.MediaCrypto,%20int)
 - hardware_buffer: Make `HardwareBuffer::as_ptr()` public for interop with Vulkan. (#213)
 - **Breaking:** `Configuration::country()` now returns `None` when the country is unset (akin to `Configuration::language()`)
 - Add `MediaCodec` and `MediaFormat` bindings. (#216)

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -229,14 +229,18 @@ impl MediaCodec {
     pub fn configure(
         &self,
         format: &MediaFormat,
-        surface: &NativeWindow,
+        surface: Option<&NativeWindow>,
         direction: MediaCodecDirection,
     ) -> Result<()> {
         let status = unsafe {
             ffi::AMediaCodec_configure(
                 self.as_ptr(),
                 format.as_ptr(),
-                surface.ptr().as_ptr(),
+                if let Some(surface) = surface {
+                    surface.ptr().as_ptr()
+                } else {
+                    ptr::null_mut()
+                },
                 ptr::null_mut(),
                 if direction == MediaCodecDirection::Encoder {
                     1

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -239,7 +239,7 @@ impl MediaCodec {
                 surface.map_or(ptr::null_mut(), |s| s.ptr().as_ptr()),
                 ptr::null_mut(),
                 if direction == MediaCodecDirection::Encoder {
-                    1
+                    ffi::AMEDIACODEC_CONFIGURE_FLAG_ENCODE as u32
                 } else {
                     0
                 },

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -236,11 +236,7 @@ impl MediaCodec {
             ffi::AMediaCodec_configure(
                 self.as_ptr(),
                 format.as_ptr(),
-                if let Some(surface) = surface {
-                    surface.ptr().as_ptr()
-                } else {
-                    ptr::null_mut()
-                },
+                surface.map_or(ptr::null_mut(), |s| s.ptr().as_ptr()),
                 ptr::null_mut(),
                 if direction == MediaCodecDirection::Encoder {
                     1


### PR DESCRIPTION
For rendering outside a surface, you can pass a null in the C++ bindings, so translate this to a `None` in Rust side.

https://developer.android.com/reference/android/media/MediaCodec#configure(android.media.MediaFormat,%20android.view.Surface,%20android.media.MediaCrypto,%20int)