### PR TITLE
Release ndk-sys-0.4.0, ndk-0.7.0, ndk-glue-0.7.0

### DIFF
--- a/ndk-glue/CHANGELOG.md
+++ b/ndk-glue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.7.0 (2022-07-24)
+
 - **Breaking:** Provide a `LockReadGuard` newtype around `NativeWindow`/`InputQueue` to hide the underlying lock implementation. (#288)
 - **Breaking:** Transpose `LockReadGuard<Option<T>>` into `Option<LockReadGuard<T>>` to only necessitate an `Option` unpack/`unwrap()` once. (#282)
 

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-glue"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Startup code for android binaries"
@@ -15,10 +15,10 @@ repository = "https://github.com/rust-windowing/android-ndk-rs"
 android_logger = { version = "0.11", optional = true }
 libc = "0.2.84"
 log = "0.4.14"
-ndk = { path = "../ndk", version = "0.6.0" }
+ndk = { path = "../ndk", version = "0.7.0" }
 ndk-context = { path = "../ndk-context", version = "0.1.1" }
 ndk-macro = { path = "../ndk-macro", version = "0.3.0" }
-ndk-sys = { path = "../ndk-sys", version = "0.3.0" }
+ndk-sys = { path = "../ndk-sys", version = "0.4.0" }
 once_cell = "1"
 parking_lot = "0.12"
 

--- a/ndk-sys/CHANGELOG.md
+++ b/ndk-sys/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.4.0 (2022-07-24)
+
 - **Breaking:** Turn `enum` type aliases into newtype wrappers. (#245, #315)
 
 # 0.3.0 (2022-01-05)

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-sys"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "FFI bindings for the Android NDK"

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Unreleased
 
+# 0.7.0 (2022-07-24)
+
 - hardware_buffer: Make `HardwareBuffer::as_ptr()` public for interop with Vulkan. (#213)
-- **Breaking:** `Configuration::country()` now returns `None` when the country is unset (akin to `Configuration::language()`)
+- **Breaking:** `Configuration::country()` now returns `None` when the country is unset (akin to `Configuration::language()`). (#220)
 - Add `MediaCodec` and `MediaFormat` bindings. (#216)
-- **Breaking:** Upgrade to [`ndk-sys 0.4.0`](../ndk-sys/CHANGELOG.md#040-TODO-YET-UNRELEASED) and use new `enum` newtype wrappers. (#245)
+- **Breaking:** Upgrade to [`ndk-sys 0.4.0`](../ndk-sys/CHANGELOG.md#040-2022-07-XXXX) and use new `enum` newtype wrappers. (#245)
 - native_window: Use `release`/`acquire` for `Drop` and `Clone` respectively. (#207)
 - **Breaking:** audio: Rename from `aaudio` to `audio` and drop `A` prefix. (#273)
 - Implement `HasRawWindowHandle` directly on `NativeWindow`. (#274, #319)

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The Rust Windowing contributors"]
 edition = "2018"
 description = "Safe Rust bindings to the Android NDK"
@@ -47,7 +47,7 @@ optional = true
 [dependencies.ffi]
 package = "ndk-sys"
 path = "../ndk-sys"
-version = "0.3.0"
+version = "0.4.0"
 
 [package.metadata.docs.rs]
 features = ["jni", "jni-glue", "all"]


### PR DESCRIPTION
Almost over the finish line!  Still have a few things to clean up, but we can unblock `winit 0.27` really soon!
