### PR TITLE
ndk: Remove "irrelevant" `hardware_buffer`/`trace` feature in favour of API level

### DIFF
--- a/ndk-examples/Cargo.toml
+++ b/ndk-examples/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 jni = "0.19"
 libc = "0.2"
 log = "0.4.14"
-ndk = { path = "../ndk", features = ["trace"] }
+ndk = { path = "../ndk", features = ["api-level-23"] }
 ndk-context = { path = "../ndk-context" }
 ndk-glue = { path = "../ndk-glue", features = ["logger"] }
 

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed `HardwareBuffer` leak on buffers returned from `AndroidBitmap::get_hardware_buffer()`. (#296)
 - **Breaking:** Update `jni` crate (used in public API) from `0.18` to `0.19`. (#300)
 - hardware_buffer: Made `HardwareBufferDesc` fields `pub`. (#313)
+- **Breaking:** Remove `hardware_buffer` and `trace` features in favour of using `api-level-26` or `api-level-23` directly. (#320)
 
 # 0.6.0 (2022-01-05)
 

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -12,13 +12,11 @@ homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
 
 [features]
-all = ["audio", "bitmap", "hardware_buffer", "media", "trace", "api-level-30"]
+all = ["audio", "bitmap","media", "api-level-30"]
 
 audio = ["ffi/audio", "api-level-26"]
 bitmap = ["ffi/bitmap"]
-hardware_buffer = ["api-level-26"]
 media = ["ffi/media"]
-trace = ["api-level-23"]
 
 api-level-23 = []
 api-level-24 = ["api-level-23"]

--- a/ndk/src/bitmap.rs
+++ b/ndk/src/bitmap.rs
@@ -8,9 +8,9 @@
 
 use jni_sys::{jobject, JNIEnv};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use std::{convert::TryInto, mem::MaybeUninit, ptr::NonNull};
+use std::{convert::TryInto, mem::MaybeUninit};
 
-#[cfg(feature = "hardware_buffer")]
+#[cfg(feature = "api-level-30")]
 use crate::hardware_buffer::HardwareBufferRef;
 
 #[repr(i32)]
@@ -104,15 +104,15 @@ impl AndroidBitmap {
     /// Retrieve the native object associated with a `HARDWARE` [`AndroidBitmap`].
     ///
     /// Client must not modify it while an [`AndroidBitmap`] is wrapping it.
-    #[cfg(all(feature = "hardware_buffer", feature = "api-level-30"))]
+    #[cfg(feature = "api-level-30")]
     pub fn get_hardware_buffer(&self) -> BitmapResult<HardwareBufferRef> {
         unsafe {
             let result =
                 construct(|res| ffi::AndroidBitmap_getHardwareBuffer(self.env, self.inner, res))?;
             let non_null = if cfg!(debug_assertions) {
-                NonNull::new(result).expect("result should never be null")
+                std::ptr::NonNull::new(result).expect("result should never be null")
             } else {
-                NonNull::new_unchecked(result)
+                std::ptr::NonNull::new_unchecked(result)
             };
             Ok(HardwareBufferRef::from_ptr(non_null))
         }

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -2,7 +2,7 @@
 //!
 //! [`AHardwareBuffer`]: https://developer.android.com/ndk/reference/group/a-hardware-buffer#ahardwarebuffer
 
-#![cfg(feature = "hardware_buffer")]
+#![cfg(feature = "api-level-26")]
 
 use crate::utils::status_to_io_result;
 

--- a/ndk/src/media/image_reader.rs
+++ b/ndk/src/media/image_reader.rs
@@ -19,7 +19,7 @@ use std::{
 #[cfg(feature = "api-level-26")]
 use std::os::unix::io::RawFd;
 
-#[cfg(feature = "hardware_buffer")]
+#[cfg(feature = "api-level-26")]
 use crate::hardware_buffer::{HardwareBuffer, HardwareBufferUsage};
 
 #[repr(u32)]
@@ -47,7 +47,7 @@ pub enum ImageFormat {
 
 pub type ImageListener = Box<dyn FnMut(&ImageReader)>;
 
-#[cfg(feature = "hardware_buffer")]
+#[cfg(feature = "api-level-26")]
 pub type BufferRemovedListener = Box<dyn FnMut(&ImageReader, &HardwareBuffer)>;
 
 /// A native [`AImageReader *`]
@@ -56,7 +56,7 @@ pub type BufferRemovedListener = Box<dyn FnMut(&ImageReader, &HardwareBuffer)>;
 pub struct ImageReader {
     inner: NonNull<ffi::AImageReader>,
     image_cb: Option<Box<ImageListener>>,
-    #[cfg(feature = "hardware_buffer")]
+    #[cfg(feature = "api-level-26")]
     buffer_removed_cb: Option<Box<BufferRemovedListener>>,
 }
 
@@ -80,7 +80,7 @@ impl ImageReader {
         Self {
             inner,
             image_cb: None,
-            #[cfg(feature = "hardware_buffer")]
+            #[cfg(feature = "api-level-26")]
             buffer_removed_cb: None,
         }
     }
@@ -97,7 +97,7 @@ impl ImageReader {
         Ok(Self::from_ptr(inner))
     }
 
-    #[cfg(feature = "hardware_buffer")]
+    #[cfg(feature = "api-level-26")]
     pub fn new_with_usage(
         width: i32,
         height: i32,
@@ -143,7 +143,7 @@ impl ImageReader {
         NdkMediaError::from_status(status)
     }
 
-    #[cfg(feature = "hardware_buffer")]
+    #[cfg(feature = "api-level-26")]
     pub fn set_buffer_removed_listener(&mut self, listener: BufferRemovedListener) -> Result<()> {
         let mut boxed = Box::new(listener);
         let ptr: *mut BufferRemovedListener = &mut *boxed;
@@ -343,7 +343,7 @@ impl Image {
     /// returned from this function, it must also register a listener using
     /// [`ImageReader::set_buffer_removed_listener()`] to be notified when the buffer is no longer
     /// used by [`ImageReader`].
-    #[cfg(feature = "hardware_buffer")]
+    #[cfg(feature = "api-level-26")]
     pub fn get_hardware_buffer(&self) -> Result<HardwareBuffer> {
         unsafe {
             let ptr =

--- a/ndk/src/trace.rs
+++ b/ndk/src/trace.rs
@@ -1,7 +1,7 @@
 //! Bindings for the NDK tracing API.
 //!
 //! See also [the NDK docs](https://developer.android.com/ndk/reference/group/tracing)
-#![cfg(feature = "trace")]
+#![cfg(feature = "api-level-23")]
 use std::ffi::{CString, NulError};
 use std::marker::PhantomData;
 


### PR DESCRIPTION
Fixes #318

Thus far feature flags have been used specifically in `ndk-sys` to control what native libraries are linked to, for content that is provided outside of the standard linked `libandroid.so`:

https://github.com/rust-windowing/android-ndk-rs/blob/d104d01f116b537babdc94d8c9889581f8d63a02/ndk-sys/src/lib.rs#L43-L53

However, `hardware_buffer` and `trace` are available in `libandroid.so` directly making these features only guard our Rust bindings.  This is unnecessarily tedious and inconsistent with the rest of the NDK wrappers which are only guarded by their minimum API level.
