### PR TITLE
ndk: Add `tool_type` getter for `Pointer` events

### DIFF
--- a/ndk-sys/CHANGELOG.md
+++ b/ndk-sys/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Unreleased
 
-- Add `tool_type` getter for `Pointer` events. (#323)
-
 # 0.4.0 (2022-07-24)
 
 - **Breaking:** Turn `enum` type aliases into newtype wrappers. (#245, #315)

--- a/ndk-sys/CHANGELOG.md
+++ b/ndk-sys/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `tool_type` getter for `Pointer` events. (#323)
+
 # 0.4.0 (2022-07-24)
 
 - **Breaking:** Turn `enum` type aliases into newtype wrappers. (#245, #315)

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 0.7.0 (2022-07-24)
 
+- event: Add `tool_type` getter for `Pointer`. (#323)
 - hardware_buffer: Make `HardwareBuffer::as_ptr()` public for interop with Vulkan. (#213)
 - **Breaking:** `Configuration::country()` now returns `None` when the country is unset (akin to `Configuration::language()`). (#220)
 - Add `MediaCodec` and `MediaFormat` bindings. (#216)

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Unreleased
 
+- event: Add `tool_type` getter for `Pointer`. (#323)
+
 # 0.7.0 (2022-07-24)
 
-- event: Add `tool_type` getter for `Pointer`. (#323)
 - hardware_buffer: Make `HardwareBuffer::as_ptr()` public for interop with Vulkan. (#213)
 - **Breaking:** `Configuration::country()` now returns `None` when the country is unset (akin to `Configuration::language()`). (#220)
 - Add `MediaCodec` and `MediaFormat` bindings. (#216)

--- a/ndk/src/event.rs
+++ b/ndk/src/event.rs
@@ -271,6 +271,20 @@ pub enum Axis {
     Generic16 = ffi::AMOTION_EVENT_AXIS_GENERIC_16,
 }
 
+/// The tool type of a pointer.
+///
+/// See [the NDK docs](https://developer.android.com/ndk/reference/group/input#anonymous-enum-48)
+#[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
+#[repr(u32)]
+pub enum ToolType {
+    Unknown = ffi::AMOTION_EVENT_TOOL_TYPE_UNKNOWN,
+    Finger = ffi::AMOTION_EVENT_TOOL_TYPE_FINGER,
+    Stylus = ffi::AMOTION_EVENT_TOOL_TYPE_STYLUS,
+    Mouse = ffi::AMOTION_EVENT_TOOL_TYPE_MOUSE,
+    Eraser = ffi::AMOTION_EVENT_TOOL_TYPE_ERASER,
+    Palm = ffi::AMOTION_EVENT_TOOL_TYPE_PALM,
+}
+
 /// A bitfield representing the state of buttons during a motion event.
 ///
 /// See [the NDK docs](https://developer.android.com/ndk/reference/group/input#anonymous-enum-33)
@@ -655,6 +669,14 @@ impl<'a> Pointer<'a> {
     #[inline]
     pub fn touch_minor(&self) -> f32 {
         unsafe { ffi::AMotionEvent_getTouchMinor(self.event.as_ptr(), self.index as ffi::size_t) }
+    }
+
+    #[inline]
+    pub fn tool_type(&self) -> ToolType {
+        let tool_type = unsafe {
+            ffi::AMotionEvent_getToolType(self.event.as_ptr(), self.index as ffi::size_t) as u32
+        };
+        tool_type.try_into().unwrap()
     }
 }
 


### PR DESCRIPTION
I'm working on a PR for winit that adds stylus support for Windows and Android.
This getter is required to differentiate between touch, mouse and stylus inputs consistently.