### PR TITLE
ndk/input: Allow any non-zero return in `pre_dispatch()` again

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - event: Add `tool_type` getter for `Pointer`. (#323)
+- input_queue: Allow any non-zero return code from `pre_dispatch()` again, as per documentation. (#325)
 
 # 0.7.0 (2022-07-24)
 

--- a/ndk/src/input_queue.rs
+++ b/ndk/src/input_queue.rs
@@ -78,8 +78,7 @@ impl InputQueue {
         match unsafe { ffi::AInputQueue_preDispatchEvent(self.ptr.as_ptr(), event.ptr().as_ptr()) }
         {
             0 => Some(event),
-            1 => None,
-            r => unreachable!("AInputQueue_preDispatchEvent returned non-boolean {}", r),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
Fixes #322

Despite the [Android source] never returning anything other than `0` or `1` there appear to be platforms out in the wild that take [the documentation] quite literally and return vague non-zero codes apart `1` with a possible secondary meaning.

[Android source]: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/jni/android_view_InputQueue.cpp;drc=b6d7f3b484e4c32c144c66bee342c29e7a8d34cc;l=115
[the documentation]: https://developer.android.com/ndk/reference/group/input#ainputqueue_predispatchevent
