### PR TITLE
Add --device arg to be able to run on specific android devices

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `--device` argument to select `adb` device by serial (see `adb devices` for connected devices and their serial). ([#329](https://github.com/rust-windowing/android-ndk-rs/pull/329))
+
 # 0.9.3 (2022-07-05)
 
 - Allow configuration of alternate debug keystore location; require keystore location for release builds. ([#299](https://github.com/rust-windowing/android-ndk-rs/pull/299))

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -234,15 +234,15 @@ impl<'a> ApkBuilder<'a> {
         Ok(apk.align()?.sign(signing_key)?)
     }
 
-    pub fn run(&self, artifact: &Artifact) -> Result<(), Error> {
+    pub fn run(&self, artifact: &Artifact, device_name: Option<String>) -> Result<(), Error> {
         let apk = self.build(artifact)?;
-        apk.install()?;
-        apk.start()?;
+        apk.install(device_name.clone())?;
+        apk.start(device_name)?;
         Ok(())
     }
 
-    pub fn gdb(&self, artifact: &Artifact) -> Result<(), Error> {
-        self.run(artifact)?;
+    pub fn gdb(&self, artifact: &Artifact, device_name: Option<String>) -> Result<(), Error> {
+        self.run(artifact, device_name)?;
         let abi = self.ndk.detect_abi()?;
         let target_dir = self.build_dir.join(artifact);
         let jni_dir = target_dir.join("jni");

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -17,6 +17,7 @@ pub struct ApkBuilder<'a> {
     manifest: Manifest,
     build_dir: PathBuf,
     build_targets: Vec<Target>,
+    device_serial: Option<String>,
 }
 
 impl<'a> ApkBuilder<'a> {
@@ -31,7 +32,9 @@ impl<'a> ApkBuilder<'a> {
         } else if !manifest.build_targets.is_empty() {
             manifest.build_targets.clone()
         } else {
-            vec![ndk.detect_abi(device_serial).unwrap_or(Target::Arm64V8a)]
+            vec![ndk
+                .detect_abi(device_serial.as_deref())
+                .unwrap_or(Target::Arm64V8a)]
         };
         let build_dir = dunce::simplified(cmd.target_dir())
             .join(cmd.profile())
@@ -96,6 +99,7 @@ impl<'a> ApkBuilder<'a> {
             manifest,
             build_dir,
             build_targets,
+            device_serial,
         })
     }
 
@@ -237,16 +241,16 @@ impl<'a> ApkBuilder<'a> {
         Ok(apk.align()?.sign(signing_key)?)
     }
 
-    pub fn run(&self, artifact: &Artifact, device_serial: Option<String>) -> Result<(), Error> {
+    pub fn run(&self, artifact: &Artifact) -> Result<(), Error> {
         let apk = self.build(artifact)?;
-        apk.install(device_serial.clone())?;
-        apk.start(device_serial)?;
+        apk.install(self.device_serial.as_deref())?;
+        apk.start(self.device_serial.as_deref())?;
         Ok(())
     }
 
-    pub fn gdb(&self, artifact: &Artifact, device_serial: Option<String>) -> Result<(), Error> {
-        self.run(artifact, device_serial.clone())?;
-        let abi = self.ndk.detect_abi(device_serial)?;
+    pub fn gdb(&self, artifact: &Artifact) -> Result<(), Error> {
+        self.run(artifact)?;
+        let abi = self.ndk.detect_abi(self.device_serial.as_deref())?;
         let target_dir = self.build_dir.join(artifact);
         let jni_dir = target_dir.join("jni");
         std::fs::create_dir_all(&jni_dir)?;

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -6,12 +6,12 @@ fn main() -> anyhow::Result<()> {
     env_logger::init();
     let mut args = std::env::args();
     let mut new_args: Vec<String> = vec![];
-    let mut device_name = None;
+    let mut device_serial = None;
 
     while let Some(name) = args.next() {
         if name == "--device" {
             if let Some(dev_name_arg) = args.next() {
-                device_name = Some(dev_name_arg);
+                device_serial = Some(dev_name_arg);
             } else {
                 println!("Expected device name after `--device`");
                 return Err(Error::invalid_args().into());
@@ -21,13 +21,13 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    if let Some(device_name) = &device_name {
-        println!("Running on {}", device_name);
+    if let Some(device_serial) = &device_serial {
+        println!("Running on {}", device_serial);
     }
 
     let cmd = Subcommand::new(new_args.into_iter(), "apk", |_, _| Ok(false))
         .map_err(Error::Subcommand)?;
-    let builder = ApkBuilder::from_subcommand(&cmd)?;
+    let builder = ApkBuilder::from_subcommand(&cmd, device_serial.clone())?;
 
     match cmd.cmd() {
         "check" | "c" => builder.check()?,
@@ -39,14 +39,14 @@ fn main() -> anyhow::Result<()> {
         "run" | "r" => {
             anyhow::ensure!(cmd.artifacts().len() == 1, Error::invalid_args());
 
-            builder.run(&cmd.artifacts()[0], device_name)?;
+            builder.run(&cmd.artifacts()[0], device_serial)?;
         }
         "--" => {
             builder.default()?;
         }
         "gdb" => {
             anyhow::ensure!(cmd.artifacts().len() == 1, Error::invalid_args());
-            builder.gdb(&cmd.artifacts()[0], device_name)?;
+            builder.gdb(&cmd.artifacts()[0], device_serial)?;
         }
         "help" => {
             if let Some(arg) = cmd.args().get(0) {

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -25,7 +25,8 @@ fn main() -> anyhow::Result<()> {
         println!("Running on {}", device_name);
     }
 
-    let cmd = Subcommand::new(new_args.into_iter(), "apk", |_, _| Ok(false)).map_err(Error::Subcommand)?;
+    let cmd = Subcommand::new(new_args.into_iter(), "apk", |_, _| Ok(false))
+        .map_err(Error::Subcommand)?;
     let builder = ApkBuilder::from_subcommand(&cmd)?;
 
     match cmd.cmd() {
@@ -37,7 +38,7 @@ fn main() -> anyhow::Result<()> {
         }
         "run" | "r" => {
             anyhow::ensure!(cmd.artifacts().len() == 1, Error::invalid_args());
-           
+
             builder.run(&cmd.artifacts()[0], device_name)?;
         }
         "--" => {

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -31,7 +31,6 @@ fn main() -> anyhow::Result<()> {
         }
         "run" | "r" => {
             anyhow::ensure!(cmd.artifacts().len() == 1, Error::invalid_args());
-
             builder.run(&cmd.artifacts()[0])?;
         }
         "--" => {
@@ -87,8 +86,8 @@ SUBCOMMAND:
     version     Print the version of cargo-apk
 
 OPTIONS:
-    --device    Serial of the device to use in `adb` commands. See `adb devices`
-                for a list of connected Android devices.
+    --device    Use device with the given serial. See `adb devices` for a list of
+                connected Android devices.
 "#
     );
 }

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -7,10 +7,14 @@ fn main() -> anyhow::Result<()> {
     let args = std::env::args();
     let mut device_serial = None;
     let cmd = Subcommand::new(args, "apk", |name, value| {
-        if let ("--device", Some(value)) = (name, value) {
-            println!("Running on {}", value);
-            device_serial = Some(value.to_owned());
-            Ok(true)
+        if name == "--device" {
+            if let Some(value) = value {
+                println!("Running on {}", value);
+                device_serial = Some(value.to_owned());
+                Ok(true)
+            } else {
+                Err(cargo_subcommand::Error::InvalidArgs)
+            }
         } else {
             Ok(false)
         }

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -92,6 +92,10 @@ SUBCOMMAND:
     run, r      Run a binary or example of the local package
     gdb         Start a gdb session attached to an adb device with symbols loaded
     version     Print the version of cargo-apk
+
+OPTIONS:
+    --device    Serial of the device to use in `adb` commands. See `adb devices`
+                for a list of connected Android devices.
 "#
     );
 }

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> anyhow::Result<()> {
 
     let cmd = Subcommand::new(new_args.into_iter(), "apk", |_, _| Ok(false))
         .map_err(Error::Subcommand)?;
-    let builder = ApkBuilder::from_subcommand(&cmd, device_serial.clone())?;
+    let builder = ApkBuilder::from_subcommand(&cmd, device_serial)?;
 
     match cmd.cmd() {
         "check" | "c" => builder.check()?,
@@ -39,14 +39,14 @@ fn main() -> anyhow::Result<()> {
         "run" | "r" => {
             anyhow::ensure!(cmd.artifacts().len() == 1, Error::invalid_args());
 
-            builder.run(&cmd.artifacts()[0], device_serial)?;
+            builder.run(&cmd.artifacts()[0])?;
         }
         "--" => {
             builder.default()?;
         }
         "gdb" => {
             anyhow::ensure!(cmd.artifacts().len() == 1, Error::invalid_args());
-            builder.gdb(&cmd.artifacts()[0], device_serial)?;
+            builder.gdb(&cmd.artifacts()[0])?;
         }
         "help" => {
             if let Some(arg) = cmd.args().get(0) {

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `adb` device serial parameter to `detect_abi()` and `Apk::{install,start}()`. ([#329](https://github.com/rust-windowing/android-ndk-rs/pull/329))
+
 # 0.7.0 (2022-07-05)
 
 - Fix NDK r23 `-lgcc` workaround for target directories containing spaces. ([#298](https://github.com/rust-windowing/android-ndk-rs/pull/298))

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -176,11 +176,11 @@ impl Apk {
         }
     }
 
-    pub fn install(&self, device_name: Option<String>) -> Result<(), NdkError> {
+    pub fn install(&self, device_serial: Option<String>) -> Result<(), NdkError> {
         let mut adb = self.ndk.platform_tool(bin!("adb"))?;
 
-        if let Some(device_name) = device_name {
-            adb.arg("-s").arg(device_name);
+        if let Some(device_serial) = device_serial {
+            adb.arg("-s").arg(device_serial);
         }
 
         adb.arg("install").arg("-r").arg(&self.path);
@@ -190,11 +190,11 @@ impl Apk {
         Ok(())
     }
 
-    pub fn start(&self, device_name: Option<String>) -> Result<(), NdkError> {
+    pub fn start(&self, device_serial: Option<String>) -> Result<(), NdkError> {
         let mut adb = self.ndk.platform_tool(bin!("adb"))?;
 
-        if let Some(device_name) = device_name {
-            adb.arg("-s").arg(device_name);
+        if let Some(device_serial) = device_serial {
+            adb.arg("-s").arg(device_serial);
         }
 
         adb.arg("shell")

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -176,8 +176,13 @@ impl Apk {
         }
     }
 
-    pub fn install(&self) -> Result<(), NdkError> {
+    pub fn install(&self, device_name: Option<String>) -> Result<(), NdkError> {
         let mut adb = self.ndk.platform_tool(bin!("adb"))?;
+
+        if let Some(device_name) = device_name {
+            adb.arg("-s").arg(device_name);
+        }
+
         adb.arg("install").arg("-r").arg(&self.path);
         if !adb.status()?.success() {
             return Err(NdkError::CmdFailed(adb));
@@ -185,8 +190,13 @@ impl Apk {
         Ok(())
     }
 
-    pub fn start(&self) -> Result<(), NdkError> {
+    pub fn start(&self, device_name: Option<String>) -> Result<(), NdkError> {
         let mut adb = self.ndk.platform_tool(bin!("adb"))?;
+        
+        if let Some(device_name) = device_name {
+            adb.arg("-s").arg(device_name);
+        }
+
         adb.arg("shell")
             .arg("am")
             .arg("start")

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -176,7 +176,7 @@ impl Apk {
         }
     }
 
-    pub fn install(&self, device_serial: Option<String>) -> Result<(), NdkError> {
+    pub fn install(&self, device_serial: Option<&str>) -> Result<(), NdkError> {
         let mut adb = self.ndk.platform_tool(bin!("adb"))?;
 
         if let Some(device_serial) = device_serial {
@@ -190,7 +190,7 @@ impl Apk {
         Ok(())
     }
 
-    pub fn start(&self, device_serial: Option<String>) -> Result<(), NdkError> {
+    pub fn start(&self, device_serial: Option<&str>) -> Result<(), NdkError> {
         let mut adb = self.ndk.platform_tool(bin!("adb"))?;
 
         if let Some(device_serial) = device_serial {

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -192,7 +192,7 @@ impl Apk {
 
     pub fn start(&self, device_name: Option<String>) -> Result<(), NdkError> {
         let mut adb = self.ndk.platform_tool(bin!("adb"))?;
-        
+
         if let Some(device_name) = device_name {
             adb.arg("-s").arg(device_name);
         }

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -377,9 +377,14 @@ impl Ndk {
         Err(NdkError::PlatformNotFound(min_sdk_version))
     }
 
-    pub fn detect_abi(&self) -> Result<Target, NdkError> {
-        let stdout = self
-            .platform_tool("adb")?
+    pub fn detect_abi(&self, device_serial: Option<String>) -> Result<Target, NdkError> {
+        let mut adb = self.platform_tool("adb")?;
+
+        if let Some(device_serial) = device_serial {
+            adb.arg("-s").arg(device_serial);
+        }
+
+        let stdout = adb
             .arg("shell")
             .arg("getprop")
             .arg("ro.product.cpu.abi")

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -377,7 +377,7 @@ impl Ndk {
         Err(NdkError::PlatformNotFound(min_sdk_version))
     }
 
-    pub fn detect_abi(&self, device_serial: Option<String>) -> Result<Target, NdkError> {
+    pub fn detect_abi(&self, device_serial: Option<&str>) -> Result<Target, NdkError> {
         let mut adb = self.platform_tool("adb")?;
 
         if let Some(device_serial) = device_serial {


### PR DESCRIPTION
This feels quite hacky, but it doesn't look like cargo_subcommand has adequate functionality to filter or add new arguments to some of the commands. 

This adds support for a `--device` arg in both `cargo apk run` and `cargo apk gdb` to run on a specific device whenever one is present.