### PR TITLE
ndk-build: Add `ndk_gdb()` function to acquire `ndk-gdb` script path with the correct per-platform extension

### DIFF
--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -258,7 +258,7 @@ impl<'a> ApkBuilder<'a> {
             jni_dir.join("Android.mk"),
             format!("APP_ABI=\"{}\"\nTARGET_OUT=\"\"\n", abi.android_abi()),
         )?;
-        Command::new(self.ndk.ndk().join("ndk-gdb"))
+        Command::new(self.ndk.ndk_gdb())
             .current_dir(target_dir)
             .status()?;
         Ok(())

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `adb` device serial parameter to `detect_abi()` and `Apk::{install,start}()`. ([#329](https://github.com/rust-windowing/android-ndk-rs/pull/329))
 - Fix missing `.exe` extension for `adb` on Windows inside `detect_abi()`. ([#339](https://github.com/rust-windowing/android-ndk-rs/pull/339))
 - `start()` now returns the PID of the started app process (useful for passing to `adb logcat --pid`). ([#331](https://github.com/rust-windowing/android-ndk-rs/pull/331))
+- Add `ndk_gdb()` function to acquire `ndk-gdb` script path with the appropriate extension across platforms. ([#330](https://github.com/rust-windowing/android-ndk-rs/pull/330))
 
 # 0.7.0 (2022-07-05)
 

--- a/ndk-build/src/lib.rs
+++ b/ndk-build/src/lib.rs
@@ -18,6 +18,16 @@ macro_rules! bat {
     };
 }
 
+macro_rules! cmd {
+    ($cmd:expr) => {
+        if cfg!(target_os = "windows") {
+            concat!($cmd, ".cmd")
+        } else {
+            $cmd
+        }
+    };
+}
+
 pub mod apk;
 pub mod cargo;
 pub mod dylibs;

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -127,6 +127,10 @@ impl Ndk {
         &self.ndk_path
     }
 
+    pub fn ndk_gdb(&self) -> PathBuf {
+        self.ndk_path.join(cmd!("ndk-gdb"))
+    }
+
     pub fn build_tools_version(&self) -> &str {
         &self.build_tools_version
     }
@@ -378,7 +382,7 @@ impl Ndk {
     }
 
     pub fn detect_abi(&self, device_serial: Option<&str>) -> Result<Target, NdkError> {
-        let mut adb = self.platform_tool("adb")?;
+        let mut adb = self.platform_tool(bin!("adb"))?;
 
         if let Some(device_serial) = device_serial {
             adb.arg("-s").arg(device_serial);


### PR DESCRIPTION
The path to the gdb script wasn't generated properly (was missing the `.cmd` extension) and the `detect_abi` was similarly broken on windows.