### PR TITLE
ndk-build: Return PID after launching the app

### DIFF
--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -200,19 +200,37 @@ impl Apk {
         Ok(())
     }
 
-    pub fn start(&self, device_serial: Option<&str>) -> Result<(), NdkError> {
-        let mut adb = self.ndk.adb(device_serial)?;
-
-        adb.arg("shell")
+    pub fn start(&self, device_serial: Option<&str>) -> Result<u32, NdkError> {
+        let mut am_start = self.ndk.adb(device_serial)?;
+        am_start
+            .arg("shell")
             .arg("am")
             .arg("start")
+            .arg("-W")
             .arg("-a")
             .arg("android.intent.action.MAIN")
             .arg("-n")
             .arg(format!("{}/android.app.NativeActivity", &self.package_name));
-        if !adb.status()?.success() {
-            return Err(NdkError::CmdFailed(adb));
+        if !am_start.status()?.success() {
+            return Err(NdkError::CmdFailed(am_start));
         }
-        Ok(())
+
+        let pid_vec = self
+            .ndk
+            .adb(device_serial)?
+            .arg("shell")
+            .arg("pidof")
+            .arg(&self.package_name)
+            .output()?
+            .stdout;
+
+        let pid = std::str::from_utf8(&pid_vec).unwrap().trim();
+        let pid: u32 = pid
+            .parse()
+            .map_err(|e| NdkError::NotAPid(e, pid.to_owned()))?;
+
+        println!("Launched with PID {}", pid);
+
+        Ok(pid)
     }
 }

--- a/ndk-build/src/error.rs
+++ b/ndk-build/src/error.rs
@@ -1,4 +1,5 @@
 use std::io::Error as IoError;
+use std::num::ParseIntError;
 use std::path::PathBuf;
 use std::process::Command;
 use thiserror::Error;
@@ -47,4 +48,6 @@ pub enum NdkError {
     CmdFailed(Command),
     #[error(transparent)]
     Serialize(#[from] quick_xml::de::DeError),
+    #[error("String `{1}` is not a PID")]
+    NotAPid(#[source] ParseIntError, String),
 }


### PR DESCRIPTION
Depends on  #329 to apply cleanly.

Shows the process PID after launching. Requires `-W` as an `am start` arg to wait for process completion to prevent a race condition. Having the PID is useful in a lot of cases, such as filtering logs with `adb logcat --pid=...`