### PR TITLE
cargo-apk: Print and follow `adb logcat` output after starting app

### DIFF
--- a/.github/workflows/android_test.sh
+++ b/.github/workflows/android_test.sh
@@ -10,7 +10,7 @@ adb uninstall rust.example.hello_world || true
 
 if [ -z "$1" ];
 then
-    cargo apk run -p ndk-examples --target x86_64-linux-android --example hello_world
+    cargo apk run -p ndk-examples --target x86_64-linux-android --example hello_world --no-logcat
 else
     adb install -r "$1/hello_world.apk"
     adb shell am start -a android.intent.action.MAIN -n "rust.example.hello_world/android.app.NativeActivity"

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Upgrade to latest `ndk-build` to deduplicate libraries before packaging them into the APK. ([#333](https://github.com/rust-windowing/android-ndk-rs/pull/333))
 - Support `android:resizeableActivity`. ([#338](https://github.com/rust-windowing/android-ndk-rs/pull/338))
 - Add `--device` argument to select `adb` device by serial (see `adb devices` for connected devices and their serial). ([#329](https://github.com/rust-windowing/android-ndk-rs/pull/329))
+- Print and follow `adb logcat` output after starting app. ([#332](https://github.com/rust-windowing/android-ndk-rs/pull/332))
 
 # 0.9.3 (2022-07-05)
 

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -246,15 +246,14 @@ impl<'a> ApkBuilder<'a> {
         apk.install(self.device_serial.as_deref())?;
         let pid = apk.start(self.device_serial.as_deref())?;
 
-        let _handle = self
-            .ndk
+        self.ndk
             .adb(self.device_serial.as_deref())?
             .arg("logcat")
             .arg("-v")
             .arg("color")
             .arg("--pid")
             .arg(pid.to_string())
-            .spawn()?;
+            .status()?;
 
         Ok(())
     }

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -244,7 +244,16 @@ impl<'a> ApkBuilder<'a> {
     pub fn run(&self, artifact: &Artifact) -> Result<(), Error> {
         let apk = self.build(artifact)?;
         apk.install(self.device_serial.as_deref())?;
-        apk.start(self.device_serial.as_deref())?;
+        let pid = apk.start(self.device_serial.as_deref())?;
+
+        let _handle = self
+            .ndk
+            .adb(self.device_serial.as_deref())?
+            .arg("logcat")
+            .arg("--pid")
+            .arg(pid.to_string())
+            .spawn()?;
+
         Ok(())
     }
 

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -250,6 +250,8 @@ impl<'a> ApkBuilder<'a> {
             .ndk
             .adb(self.device_serial.as_deref())?
             .arg("logcat")
+            .arg("-v")
+            .arg("color")
             .arg("--pid")
             .arg(pid.to_string())
             .spawn()?;

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -18,12 +18,14 @@ pub struct ApkBuilder<'a> {
     build_dir: PathBuf,
     build_targets: Vec<Target>,
     device_serial: Option<String>,
+    no_logcat: bool,
 }
 
 impl<'a> ApkBuilder<'a> {
     pub fn from_subcommand(
         cmd: &'a Subcommand,
         device_serial: Option<String>,
+        no_logcat: bool,
     ) -> Result<Self, Error> {
         let ndk = Ndk::from_env()?;
         let mut manifest = Manifest::parse_from_toml(cmd.manifest())?;
@@ -100,6 +102,7 @@ impl<'a> ApkBuilder<'a> {
             build_dir,
             build_targets,
             device_serial,
+            no_logcat,
         })
     }
 
@@ -246,14 +249,16 @@ impl<'a> ApkBuilder<'a> {
         apk.install(self.device_serial.as_deref())?;
         let pid = apk.start(self.device_serial.as_deref())?;
 
-        self.ndk
-            .adb(self.device_serial.as_deref())?
-            .arg("logcat")
-            .arg("-v")
-            .arg("color")
-            .arg("--pid")
-            .arg(pid.to_string())
-            .status()?;
+        if !self.no_logcat {
+            self.ndk
+                .adb(self.device_serial.as_deref())?
+                .arg("logcat")
+                .arg("-v")
+                .arg("color")
+                .arg("--pid")
+                .arg(pid.to_string())
+                .status()?;
+        }
 
         Ok(())
     }

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **Breaking:** Postpone APK library packaging until before zip alignment, to deduplicate possibly overlapping entries. ([#333](https://github.com/rust-windowing/android-ndk-rs/pull/333))
 - Add `adb` device serial parameter to `detect_abi()` and `Apk::{install,start}()`. ([#329](https://github.com/rust-windowing/android-ndk-rs/pull/329))
 - Fix missing `.exe` extension for `adb` on Windows inside `detect_abi()`. ([#339](https://github.com/rust-windowing/android-ndk-rs/pull/339))
+- `start()` now returns the PID of the started app process (useful for passing to `adb logcat --pid`). ([#331](https://github.com/rust-windowing/android-ndk-rs/pull/331))
 
 # 0.7.0 (2022-07-05)
 


### PR DESCRIPTION
Depends on #331

This starts a logcat session for our PID so we have something that's a bit more akin to how `cargo run` regularly works. If this is undesired, I would also be OK with adding a `--log` argument.