### PR TITLE
Deduplicate all (recursively) added runtime libraries

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Upgrade to latest `ndk-build` to deduplicate libraries before packaging them into the APK. ([#333](https://github.com/rust-windowing/android-ndk-rs/pull/333))
+
 # 0.9.3 (2022-07-05)
 
 - Allow configuration of alternate debug keystore location; require keystore location for release builds. ([#299](https://github.com/rust-windowing/android-ndk-rs/pull/299))

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -171,7 +171,7 @@ impl<'a> ApkBuilder<'a> {
             manifest,
             disable_aapt_compression: is_debug_profile,
         };
-        let apk = config.create_apk()?;
+        let mut apk = config.create_apk()?;
 
         for target in &self.build_targets {
             let triple = target.rust_triple();
@@ -231,7 +231,7 @@ impl<'a> ApkBuilder<'a> {
             (None, false) => return Err(Error::MissingReleaseKey(profile_name.to_owned())),
         };
 
-        Ok(apk.align()?.sign(signing_key)?)
+        Ok(apk.add_pending_libs_and_align()?.sign(signing_key)?)
     }
 
     pub fn run(&self, artifact: &Artifact) -> Result<(), Error> {

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **Breaking:** Postpone APK library packaging until before zip alignment, to deduplicate possibly overlapping entries. ([#333](https://github.com/rust-windowing/android-ndk-rs/pull/333))
+
 # 0.7.0 (2022-07-05)
 
 - Fix NDK r23 `-lgcc` workaround for target directories containing spaces. ([#298](https://github.com/rust-windowing/android-ndk-rs/pull/298))

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -6,6 +6,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::collections::HashSet;
 
 pub struct ApkConfig {
     pub ndk: Ndk,
@@ -68,24 +69,30 @@ impl ApkConfig {
             return Err(NdkError::CmdFailed(aapt));
         }
 
-        Ok(UnalignedApk(self))
+        Ok(UnalignedApk {
+            config: self,
+            pending_libs: HashSet::default()
+        })
     }
 }
 
-pub struct UnalignedApk<'a>(&'a ApkConfig);
+pub struct UnalignedApk<'a> {
+    config: &'a ApkConfig,
+    pending_libs: HashSet<String>,
+}
 
 impl<'a> UnalignedApk<'a> {
     pub fn config(&self) -> &ApkConfig {
-        self.0
+        self.config
     }
 
-    pub fn add_lib(&self, path: &Path, target: Target) -> Result<(), NdkError> {
+    pub fn add_lib(&mut self, path: &Path, target: Target) -> Result<(), NdkError> {
         if !path.exists() {
             return Err(NdkError::PathNotFound(path.into()));
         }
         let abi = target.android_abi();
         let lib_path = Path::new("lib").join(abi).join(path.file_name().unwrap());
-        let out = self.0.build_dir.join(&lib_path);
+        let out = self.config.build_dir.join(&lib_path);
         std::fs::create_dir_all(out.parent().unwrap())?;
         std::fs::copy(path, out)?;
 
@@ -94,23 +101,13 @@ impl<'a> UnalignedApk<'a> {
         // Otherwise, it results in a runtime error when loading the NativeActivity `.so` library.
         let lib_path_unix = lib_path.to_str().unwrap().replace('\\', "/");
 
-        let mut aapt = self.0.build_tool(bin!("aapt"))?;
-        aapt.arg("add");
+        self.pending_libs.insert(lib_path_unix);
 
-        if self.0.disable_aapt_compression {
-            aapt.arg("-0").arg("");
-        }
-
-        aapt.arg(self.0.unaligned_apk()).arg(lib_path_unix);
-
-        if !aapt.status()?.success() {
-            return Err(NdkError::CmdFailed(aapt));
-        }
         Ok(())
     }
 
     pub fn add_runtime_libs(
-        &self,
+        &mut self,
         path: &Path,
         target: Target,
         search_paths: &[&Path],
@@ -126,18 +123,33 @@ impl<'a> UnalignedApk<'a> {
         Ok(())
     }
 
-    pub fn align(self) -> Result<UnsignedApk<'a>, NdkError> {
-        let mut zipalign = self.0.build_tool(bin!("zipalign"))?;
+    pub fn add_pending_libs_and_align(self) -> Result<UnsignedApk<'a>, NdkError> {
+        for lib_path_unix in self.pending_libs {
+            let mut aapt = self.config.build_tool(bin!("aapt"))?;
+            aapt.arg("add");
+
+            if self.config.disable_aapt_compression {
+                aapt.arg("-0").arg("");
+            }
+
+            aapt.arg(self.config.unaligned_apk()).arg(lib_path_unix);
+
+            if !aapt.status()?.success() {
+                return Err(NdkError::CmdFailed(aapt));
+            }
+        }
+        
+        let mut zipalign = self.config.build_tool(bin!("zipalign"))?;
         zipalign
             .arg("-f")
             .arg("-v")
             .arg("4")
-            .arg(self.0.unaligned_apk())
-            .arg(self.0.apk());
+            .arg(self.config.unaligned_apk())
+            .arg(self.config.apk());
         if !zipalign.status()?.success() {
             return Err(NdkError::CmdFailed(zipalign));
         }
-        Ok(UnsignedApk(self.0))
+        Ok(UnsignedApk(self.config))
     }
 }
 

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -2,11 +2,11 @@ use crate::error::NdkError;
 use crate::manifest::AndroidManifest;
 use crate::ndk::{Key, Ndk};
 use crate::target::Target;
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::collections::HashSet;
 
 pub struct ApkConfig {
     pub ndk: Ndk,
@@ -71,7 +71,7 @@ impl ApkConfig {
 
         Ok(UnalignedApk {
             config: self,
-            pending_libs: HashSet::default()
+            pending_libs: HashSet::default(),
         })
     }
 }
@@ -138,7 +138,7 @@ impl<'a> UnalignedApk<'a> {
                 return Err(NdkError::CmdFailed(aapt));
             }
         }
-        
+
         let mut zipalign = self.config.build_tool(bin!("zipalign"))?;
         zipalign
             .arg("-f")

--- a/ndk-build/src/readelf.rs
+++ b/ndk-build/src/readelf.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 
 impl<'a> UnalignedApk<'a> {
     pub fn add_lib_recursively(
-        &self,
+        &mut self,
         lib: &Path,
         target: Target,
         search_paths: &[&Path],


### PR DESCRIPTION
Builds on #246 but cleans it up a bit. 

We started to run into this since the Vulkan-SDK started building with `libc++_shared.so` in https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/a64eec06b8a155c8deb3f27411c4a322faa95e9f