### PR TITLE
ndk-build: Support `android:resizeableActivity`

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Upgrade to latest `ndk-build` to deduplicate libraries before packaging them into the APK. ([#333](https://github.com/rust-windowing/android-ndk-rs/pull/333))
+- Support `android:resizeableActivity`.
 
 # 0.9.3 (2022-07-05)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - Upgrade to latest `ndk-build` to deduplicate libraries before packaging them into the APK. ([#333](https://github.com/rust-windowing/android-ndk-rs/pull/333))
-- Support `android:resizeableActivity`.
+- Support `android:resizeableActivity`. ([#338](https://github.com/rust-windowing/android-ndk-rs/pull/338))
 
 # 0.9.3 (2022-07-05)
 

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -159,6 +159,11 @@ orientation = "landscape"
 # Unset by default, or "true" when targeting Android >= 31 (S and up).
 exported = "true"
 
+# See https://developer.android.com/guide/topics/manifest/activity-element#resizeableActivity
+#
+# Unset by default, or "true" when targeting Android >= 24 (Nougat and up).
+resizeable_activity = "true"
+
 # See https://developer.android.com/guide/topics/manifest/meta-data-element
 #
 # Note: there can be several .meta_data entries.

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -156,13 +156,13 @@ orientation = "landscape"
 
 # See https://developer.android.com/guide/topics/manifest/activity-element#exported
 #
-# Unset by default, or "true" when targeting Android >= 31 (S and up).
-exported = "true"
+# Unset by default, or true when targeting Android >= 31 (S and up).
+exported = true
 
 # See https://developer.android.com/guide/topics/manifest/activity-element#resizeableActivity
 #
-# Unset by default, or "true" when targeting Android >= 24 (Nougat and up).
-resizeable_activity = "true"
+# Defaults to true on Android >= 24, no effect on earlier API levels
+resizeable_activity = false
 
 # See https://developer.android.com/guide/topics/manifest/meta-data-element
 #

--- a/ndk-build/src/manifest.rs
+++ b/ndk-build/src/manifest.rs
@@ -102,6 +102,8 @@ pub struct Activity {
     pub orientation: Option<String>,
     #[serde(rename(serialize = "android:exported"))]
     pub exported: Option<bool>,
+    #[serde(rename(serialize = "android:resizeableActivity"))]
+    pub resizeable_activity: Option<bool>,
 
     #[serde(rename(serialize = "meta-data"))]
     #[serde(default)]
@@ -121,6 +123,7 @@ impl Default for Activity {
             name: default_activity_name(),
             orientation: None,
             exported: None,
+            resizeable_activity: None,
             meta_data: Default::default(),
             intent_filter: Default::default(),
         }


### PR DESCRIPTION
This is a trivial pull request to add support for the [`android:resizeableActivity`](https://developer.android.com/guide/topics/manifest/activity-element#resizeableActivity) attribute on `<activity>`, needed e.g. for [manifests for the Oculus Quest](https://developer.oculus.com/documentation/native/android/mobile-native-manifest/) VR headset.