### PR TITLE
cargo-apk: Pass device serial to `ndk-gdb`

### DIFF
--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -273,9 +273,15 @@ impl<'a> ApkBuilder<'a> {
             jni_dir.join("Android.mk"),
             format!("APP_ABI=\"{}\"\nTARGET_OUT=\"\"\n", abi.android_abi()),
         )?;
-        Command::new(self.ndk.ndk_gdb())
-            .current_dir(target_dir)
-            .status()?;
+
+        let mut ndk_gdb = Command::new(self.ndk.ndk_gdb());
+
+        if let Some(device_serial) = &self.device_serial {
+            ndk_gdb.arg("-s").arg(device_serial);
+        }
+
+        ndk_gdb.current_dir(target_dir).status()?;
+
         Ok(())
     }
 


### PR DESCRIPTION
`ndk-gdb` must use the same device as `.run()` previously launched the app on.
