### PR TITLE
cargo-apk: Force-disable logcat in `fn run()` when using `gdb`

### DIFF
--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -24,6 +24,11 @@ fn main() -> anyhow::Result<()> {
         _ => Ok(false),
     })
     .map_err(Error::Subcommand)?;
+
+    if cmd.cmd() == "gdb" {
+        no_logcat = true;
+    }
+
     let builder = ApkBuilder::from_subcommand(&cmd, device_serial, no_logcat)?;
 
     match cmd.cmd() {


### PR DESCRIPTION
The terminal must be available for GDB to start and interact with, instead of indefinitely blocking on a running instance of `logcat`.
