### PR TITLE
ndk-build: Provide `adb` path to `ndk-gdb`

### DIFF
--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fix missing `.exe` extension for `adb` on Windows inside `detect_abi()`. ([#339](https://github.com/rust-windowing/android-ndk-rs/pull/339))
 - `start()` now returns the PID of the started app process (useful for passing to `adb logcat --pid`). ([#331](https://github.com/rust-windowing/android-ndk-rs/pull/331))
 - Inherit `ndk_gdb()` function from `cargo-apk` with the appropriate script extension across platforms. ([#330](https://github.com/rust-windowing/android-ndk-rs/pull/330), [#258](https://github.com/rust-windowing/android-ndk-rs/pull/258))
-
+- Provide `adb` path to `ndk-gdb`, allowing it to run without `adb` in `PATH`. ([#343](https://github.com/rust-windowing/android-ndk-rs/pull/343))
 
 # 0.7.0 (2022-07-05)
 


### PR DESCRIPTION
`adb` is not necessarily available in `PATH`, hence why `cargo-apk` and `ndk-build` detect and use this executable from the SDK path.  We should do the same for `ndk-gdb` which strangely doesn't search for `adb` within the SDK it resides in.