### PR TITLE
ndk-build: Remove unparsable quotes from `Android.mk` for `ndk-gdb`

### DIFF
--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `start()` now returns the PID of the started app process (useful for passing to `adb logcat --pid`). ([#331](https://github.com/rust-windowing/android-ndk-rs/pull/331))
 - Inherit `ndk_gdb()` function from `cargo-apk` with the appropriate script extension across platforms. ([#330](https://github.com/rust-windowing/android-ndk-rs/pull/330), [#258](https://github.com/rust-windowing/android-ndk-rs/pull/258))
 - Provide `adb` path to `ndk-gdb`, allowing it to run without `adb` in `PATH`. ([#343](https://github.com/rust-windowing/android-ndk-rs/pull/343))
+- Remove quotes from `Android.mk` to fix `ndk-gdb` on Windows. ([#344](https://github.com/rust-windowing/android-ndk-rs/pull/344))
 
 # 0.7.0 (2022-07-05)
 

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -316,7 +316,7 @@ impl Ndk {
         std::fs::create_dir_all(&jni_dir)?;
         std::fs::write(
             jni_dir.join("Android.mk"),
-            format!("APP_ABI=\"{}\"\nTARGET_OUT=\"\"\n", abi.android_abi()),
+            format!("APP_ABI={}\nTARGET_OUT=\n", abi.android_abi()),
         )?;
         let mut ndk_gdb = Command::new(self.prebuilt_dir()?.join("bin").join(cmd!("ndk-gdb")));
 


### PR DESCRIPTION
On Windows it seems the `ndk-gdb.py` script that invokes `make` to dump the variables from `Android.mk` fails to strip quotation marks from the file correctly, resulting in erroneous output like (notice double quotes at the end of the path):

	OSError: [WinError 123] The filename, directory name, or volume
	label syntax is incorrect:
	'android-ndk-rs\\target\\debug\\apk\\examples\\""'

And:

	Application cannot run on the selected device.
	Application ABIs: "arm64-v8a"
	Device ABIs: arm64-v8a, armeabi-v7a, armeabi

Solve this by removing the quotes, allowing `ndk-gdb` to launch sucessfully.
