### PR TITLE
ndk-build,cargo-apk: Launch activity directly through `ndk-gdb`

### DIFF
--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -263,10 +263,15 @@ impl<'a> ApkBuilder<'a> {
     }
 
     pub fn gdb(&self, artifact: &Artifact) -> Result<(), Error> {
-        self.run(artifact)?;
+        let apk = self.build(artifact)?;
+        apk.install(self.device_serial.as_deref())?;
+
         let target_dir = self.build_dir.join(artifact);
-        self.ndk
-            .ndk_gdb(&target_dir, self.device_serial.as_deref())?;
+        self.ndk.ndk_gdb(
+            &target_dir,
+            "android.app.NativeActivity",
+            self.device_serial.as_deref(),
+        )?;
         Ok(())
     }
 

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -25,10 +25,6 @@ fn main() -> anyhow::Result<()> {
     })
     .map_err(Error::Subcommand)?;
 
-    if cmd.cmd() == "gdb" {
-        no_logcat = true;
-    }
-
     let builder = ApkBuilder::from_subcommand(&cmd, device_serial, no_logcat)?;
 
     match cmd.cmd() {

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Inherit `ndk_gdb()` function from `cargo-apk` with the appropriate script extension across platforms. ([#330](https://github.com/rust-windowing/android-ndk-rs/pull/330), [#258](https://github.com/rust-windowing/android-ndk-rs/pull/258))
 - Provide `adb` path to `ndk-gdb`, allowing it to run without `adb` in `PATH`. ([#343](https://github.com/rust-windowing/android-ndk-rs/pull/343))
 - Remove quotes from `Android.mk` to fix `ndk-gdb` on Windows. ([#344](https://github.com/rust-windowing/android-ndk-rs/pull/344))
+- Launch Android activity through `ndk-gdb` to block app start until the debugger is attached. ([#345](https://github.com/rust-windowing/android-ndk-rs/pull/345))
 
 # 0.7.0 (2022-07-05)
 

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -309,6 +309,7 @@ impl Ndk {
     pub fn ndk_gdb(
         &self,
         launch_dir: impl AsRef<Path>,
+        launch_activity: &str,
         device_serial: Option<&str>,
     ) -> Result<(), NdkError> {
         let abi = self.detect_abi(device_serial)?;
@@ -327,6 +328,8 @@ impl Ndk {
         ndk_gdb
             .arg("--adb")
             .arg(self.adb_path()?)
+            .arg("--launch")
+            .arg(launch_activity)
             .current_dir(launch_dir)
             .status()?;
         Ok(())


### PR DESCRIPTION
`ndk-gdb` passes `-D` to `am start` to make the process wait until the debugger is launched and ready, instead of possibly crashing the app before the debugger can catch it (paired with a nice "waiting for debugger" dialog and "Force close" button in Android).  While we could also set the flag ourselves, this change simplifies the workflow on our end as well now that we don't have to run our own command, potentially get stuck on `pidof` returning multiple PIDs, and having to override `no_logcat` (#342).

(For the multiple-PID case though, we can optionally pass `-f` to make `ndk-gdb` kill the debugger and app first, if this ever becomes an issue.)
