### PR TITLE
ndk-build: Consider ANDROID_SDK_ROOT as deprecated instead of ANDROID_HOME

### DIFF
--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Provide `adb` path to `ndk-gdb`, allowing it to run without `adb` in `PATH`. ([#343](https://github.com/rust-windowing/android-ndk-rs/pull/343))
 - Remove quotes from `Android.mk` to fix `ndk-gdb` on Windows. ([#344](https://github.com/rust-windowing/android-ndk-rs/pull/344))
 - Launch Android activity through `ndk-gdb` to block app start until the debugger is attached. ([#345](https://github.com/rust-windowing/android-ndk-rs/pull/345))
+- Consider `ANDROID_SDK_ROOT` as deprecated instead of `ANDROID_HOME`. ([#346](https://github.com/rust-windowing/android-ndk-rs/pull/346))
 
 # 0.7.0 (2022-07-05)
 

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -16,18 +16,20 @@ pub struct Ndk {
 impl Ndk {
     pub fn from_env() -> Result<Self, NdkError> {
         let sdk_path = {
-            let mut sdk_path = std::env::var("ANDROID_HOME").ok();
+            let sdk_path = std::env::var("ANDROID_SDK_ROOT").ok();
             if sdk_path.is_some() {
-                println!(
-                    "Warning: You use environment variable ANDROID_HOME that is deprecated. \
-                 Please, remove it and use ANDROID_SDK_ROOT instead. Now ANDROID_HOME is used"
+                eprintln!(
+                    "Warning: Environment variable ANDROID_SDK_ROOT is deprecated \
+                    (https://developer.android.com/studio/command-line/variables#envar). \
+                    It will be used until it is unset and replaced by ANDROID_HOME."
                 );
             }
-            if sdk_path.is_none() {
-                sdk_path = std::env::var("ANDROID_SDK_ROOT").ok();
-            }
 
-            PathBuf::from(sdk_path.ok_or(NdkError::SdkNotFound)?)
+            PathBuf::from(
+                sdk_path
+                    .or_else(|| std::env::var("ANDROID_HOME").ok())
+                    .ok_or(NdkError::SdkNotFound)?,
+            )
         };
 
         let ndk_path = {


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/android-ndk-rs/issues/327, CC @Hoodad

According to the [official documentation] `ndk-build` is considering the wrong variable as deprecated.  The wrong message was introduced in [#39] which bizarrely failed to quote any reference matterial on the matter, making it impossible to understand whether this has always been the case or recently switched in precedence.

[official documentation]: https://developer.android.com/studio/command-line/variables
[#39]: https://github.com/rust-windowing/android-ndk-rs/pull/39