### PR TITLE
cargo-apk: Automate `adb reverse` port forwarding through `Cargo.toml` metadata

### DIFF
--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -192,6 +192,12 @@ port = "8080"
 path = "/rust-windowing/android-ndk-rs/tree/master/cargo-apk"
 path_prefix = "/rust-windowing/"
 mime_type = "image/jpeg"
+
+# Set up reverse port forwarding through `adb reverse`, meaning that if the
+# Android device connects to `https://localhost:1338` it will be routed to 
+# the localhost on the host device instead.
+[package.metadata.android.reverse_port_fwd]
+"tcp:1338" = "tcp:1338"
 ```
 
 If a manifest attribute is not supported by `cargo apk` feel free to create a PR that adds the missing attribute.

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -194,8 +194,9 @@ path_prefix = "/rust-windowing/"
 mime_type = "image/jpeg"
 
 # Set up reverse port forwarding through `adb reverse`, meaning that if the
-# Android device connects to `https://localhost:1338` it will be routed to 
-# the localhost on the host device instead.
+# Android device connects to `localhost` on port `1338` it will be routed to 
+# the host on port `1338` instead. Source and destination ports can differ,
+# see the `adb` help page for possible configurations.
 [package.metadata.android.reverse_port_forward]
 "tcp:1338" = "tcp:1338"
 ```

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -196,7 +196,7 @@ mime_type = "image/jpeg"
 # Set up reverse port forwarding through `adb reverse`, meaning that if the
 # Android device connects to `https://localhost:1338` it will be routed to 
 # the localhost on the host device instead.
-[package.metadata.android.reverse_port_fwd]
+[package.metadata.android.reverse_port_forward]
 "tcp:1338" = "tcp:1338"
 ```
 

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -179,6 +179,7 @@ impl<'a> ApkBuilder<'a> {
             resources,
             manifest,
             disable_aapt_compression: is_debug_profile,
+            reverse_port_fwd: self.manifest.reverse_port_fwd.clone(),
         };
         let mut apk = config.create_apk()?;
 
@@ -245,6 +246,7 @@ impl<'a> ApkBuilder<'a> {
 
     pub fn run(&self, artifact: &Artifact) -> Result<(), Error> {
         let apk = self.build(artifact)?;
+        apk.reverse_port_forwarding(self.device_serial.as_deref())?;
         apk.install(self.device_serial.as_deref())?;
         let pid = apk.start(self.device_serial.as_deref())?;
 

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -179,7 +179,7 @@ impl<'a> ApkBuilder<'a> {
             resources,
             manifest,
             disable_aapt_compression: is_debug_profile,
-            reverse_port_fwd: self.manifest.reverse_port_fwd.clone(),
+            reverse_port_forward: self.manifest.reverse_port_forward.clone(),
         };
         let mut apk = config.create_apk()?;
 

--- a/cargo-apk/src/manifest.rs
+++ b/cargo-apk/src/manifest.rs
@@ -73,7 +73,7 @@ struct AndroidMetadata {
     /// Maps profiles to keystores
     #[serde(default)]
     signing: HashMap<String, Signing>,
-    /// Set up reverse port forwarding before the application launches
+    /// Set up reverse port forwarding before launching the application
     #[serde(default)]
     reverse_port_forward: HashMap<String, String>,
 }

--- a/cargo-apk/src/manifest.rs
+++ b/cargo-apk/src/manifest.rs
@@ -17,7 +17,7 @@ pub(crate) struct Manifest {
     pub(crate) runtime_libs: Option<PathBuf>,
     /// Maps profiles to keystores
     pub(crate) signing: HashMap<String, Signing>,
-    pub(crate) reverse_port_fwd: HashMap<String, String>,
+    pub(crate) reverse_port_forward: HashMap<String, String>,
 }
 
 impl Manifest {
@@ -39,7 +39,7 @@ impl Manifest {
             resources: metadata.resources,
             runtime_libs: metadata.runtime_libs,
             signing: metadata.signing,
-            reverse_port_fwd: metadata.reverse_port_fwd,
+            reverse_port_forward: metadata.reverse_port_forward,
         })
     }
 }
@@ -75,7 +75,7 @@ struct AndroidMetadata {
     signing: HashMap<String, Signing>,
     /// Set up reverse port forwarding before the application launches
     #[serde(default)]
-    reverse_port_fwd: HashMap<String, String>,
+    reverse_port_forward: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/cargo-apk/src/manifest.rs
+++ b/cargo-apk/src/manifest.rs
@@ -17,6 +17,7 @@ pub(crate) struct Manifest {
     pub(crate) runtime_libs: Option<PathBuf>,
     /// Maps profiles to keystores
     pub(crate) signing: HashMap<String, Signing>,
+    pub(crate) reverse_port_fwd: HashMap<String, String>,
 }
 
 impl Manifest {
@@ -38,6 +39,7 @@ impl Manifest {
             resources: metadata.resources,
             runtime_libs: metadata.runtime_libs,
             signing: metadata.signing,
+            reverse_port_fwd: metadata.reverse_port_fwd,
         })
     }
 }
@@ -71,6 +73,9 @@ struct AndroidMetadata {
     /// Maps profiles to keystores
     #[serde(default)]
     signing: HashMap<String, Signing>,
+    /// Set up reverse port forwarding before the application launches
+    #[serde(default)]
+    reverse_port_fwd: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -197,11 +197,7 @@ impl Apk {
     pub fn reverse_port_forwarding(&self, device_serial: Option<&str>) -> Result<(), NdkError> {
         for (from, to) in &self.reverse_port_forward {
             println!("Reverse port forwarding {} {}", from, to);
-            let mut adb = self.ndk.platform_tool(bin!("adb"))?;
-
-            if let Some(device_serial) = device_serial {
-                adb.arg("-s").arg(device_serial);
-            }
+            let mut adb = self.ndk.adb(device_serial)?;
 
             adb.arg("reverse").arg(from).arg(to);
 

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -17,7 +17,7 @@ pub struct ApkConfig {
     pub resources: Option<PathBuf>,
     pub manifest: AndroidManifest,
     pub disable_aapt_compression: bool,
-    pub reverse_port_fwd: HashMap<String, String>,
+    pub reverse_port_forward: HashMap<String, String>,
 }
 
 impl ApkConfig {
@@ -180,7 +180,7 @@ pub struct Apk {
     path: PathBuf,
     package_name: String,
     ndk: Ndk,
-    reverse_port_fwd: HashMap<String, String>,
+    reverse_port_forward: HashMap<String, String>,
 }
 
 impl Apk {
@@ -190,12 +190,12 @@ impl Apk {
             path: config.apk(),
             package_name: config.manifest.package.clone(),
             ndk,
-            reverse_port_fwd: config.reverse_port_fwd.clone(),
+            reverse_port_forward: config.reverse_port_forward.clone(),
         }
     }
 
     pub fn reverse_port_forwarding(&self, device_serial: Option<&str>) -> Result<(), NdkError> {
-        for (from, to) in &self.reverse_port_fwd {
+        for (from, to) in &self.reverse_port_forward {
             println!("Reverse port forwarding {} {}", from, to);
             let mut adb = self.ndk.platform_tool(bin!("adb"))?;
 

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -2,6 +2,7 @@ use crate::error::NdkError;
 use crate::manifest::AndroidManifest;
 use crate::ndk::{Key, Ndk};
 use crate::target::Target;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
@@ -16,6 +17,7 @@ pub struct ApkConfig {
     pub resources: Option<PathBuf>,
     pub manifest: AndroidManifest,
     pub disable_aapt_compression: bool,
+    pub reverse_port_fwd: HashMap<String, String>,
 }
 
 impl ApkConfig {
@@ -178,6 +180,7 @@ pub struct Apk {
     path: PathBuf,
     package_name: String,
     ndk: Ndk,
+    reverse_port_fwd: HashMap<String, String>,
 }
 
 impl Apk {
@@ -187,7 +190,27 @@ impl Apk {
             path: config.apk(),
             package_name: config.manifest.package.clone(),
             ndk,
+            reverse_port_fwd: config.reverse_port_fwd.clone(),
         }
+    }
+
+    pub fn reverse_port_forwarding(&self, device_serial: Option<&str>) -> Result<(), NdkError> {
+        for (from, to) in &self.reverse_port_fwd {
+            println!("Reverse port forwarding {} {}", from, to);
+            let mut adb = self.ndk.platform_tool(bin!("adb"))?;
+
+            if let Some(device_serial) = device_serial {
+                adb.arg("-s").arg(device_serial);
+            }
+
+            adb.arg("reverse").arg(from).arg(to);
+
+            if !adb.status()?.success() {
+                return Err(NdkError::CmdFailed(adb));
+            }
+        }
+
+        Ok(())
     }
 
     pub fn install(&self, device_serial: Option<&str>) -> Result<(), NdkError> {

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -196,7 +196,7 @@ impl Apk {
 
     pub fn reverse_port_forwarding(&self, device_serial: Option<&str>) -> Result<(), NdkError> {
         for (from, to) in &self.reverse_port_forward {
-            println!("Reverse port forwarding {} {}", from, to);
+            println!("Reverse port forwarding from {} to {}", from, to);
             let mut adb = self.ndk.adb(device_serial)?;
 
             adb.arg("reverse").arg(from).arg(to);


### PR DESCRIPTION
This adds a feature so we can set up reverse port forwarding from our Cargo.toml file before the app starts

```toml
[package.metadata.android.reverse_port_fwd]
"tcp:1338" = "tcp:1338"
"tcp:1339" = "tcp:1339"
```