### PR TITLE
Fix `clippy::unnecessary_lazy_evaluations` since Rust 1.64

### DIFF
--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -309,14 +309,15 @@ impl Ndk {
         } else {
             let llvm_bin = format!("llvm-{}{}", name, ext);
             let llvm_path = toolchain_path.join(&llvm_bin);
-            llvm_path
-                .exists()
-                .then(|| llvm_path)
-                .ok_or(NdkError::ToolchainBinaryNotFound {
+            if llvm_path.exists() {
+                Ok(llvm_path)
+            } else {
+                Err(NdkError::ToolchainBinaryNotFound {
                     toolchain_path,
                     gnu_bin,
                     llvm_bin,
                 })
+            }
         }
     }
 

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -55,26 +55,41 @@ impl MediaFormat {
     pub fn i32(&self, key: &str) -> Option<i32> {
         let name = CString::new(key).unwrap();
         let mut out = 0;
-        unsafe { ffi::AMediaFormat_getInt32(self.as_ptr(), name.as_ptr(), &mut out) }.then(|| out)
+        if unsafe { ffi::AMediaFormat_getInt32(self.as_ptr(), name.as_ptr(), &mut out) } {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     pub fn i64(&self, key: &str) -> Option<i64> {
         let name = CString::new(key).unwrap();
         let mut out = 0;
-        unsafe { ffi::AMediaFormat_getInt64(self.as_ptr(), name.as_ptr(), &mut out) }.then(|| out)
+        if unsafe { ffi::AMediaFormat_getInt64(self.as_ptr(), name.as_ptr(), &mut out) } {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     pub fn f32(&self, key: &str) -> Option<f32> {
         let name = CString::new(key).unwrap();
         let mut out = 0.0;
-        unsafe { ffi::AMediaFormat_getFloat(self.as_ptr(), name.as_ptr(), &mut out) }.then(|| out)
+        if unsafe { ffi::AMediaFormat_getFloat(self.as_ptr(), name.as_ptr(), &mut out) } {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     pub fn usize(&self, key: &str) -> Option<usize> {
         let name = CString::new(key).unwrap();
         let mut out = 0;
-        unsafe { ffi::AMediaFormat_getSize(self.as_ptr(), name.as_ptr(), &mut out) }
-            .then(|| out as usize)
+        if unsafe { ffi::AMediaFormat_getSize(self.as_ptr(), name.as_ptr(), &mut out) } {
+            Some(out as usize)
+        } else {
+            None
+        }
     }
 
     pub fn buffer(&self, key: &str) -> Option<&[u8]> {
@@ -136,7 +151,11 @@ impl MediaFormat {
     pub fn f64(&self, key: &str) -> Option<f64> {
         let name = CString::new(key).unwrap();
         let mut out = 0.0;
-        unsafe { ffi::AMediaFormat_getDouble(self.as_ptr(), name.as_ptr(), &mut out) }.then(|| out)
+        if unsafe { ffi::AMediaFormat_getDouble(self.as_ptr(), name.as_ptr(), &mut out) } {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     /// Returns (left, top, right, bottom)
@@ -147,7 +166,7 @@ impl MediaFormat {
         let mut top = 0;
         let mut right = 0;
         let mut bottom = 0;
-        unsafe {
+        if unsafe {
             ffi::AMediaFormat_getRect(
                 self.as_ptr(),
                 name.as_ptr(),
@@ -156,8 +175,11 @@ impl MediaFormat {
                 &mut right,
                 &mut bottom,
             )
+        } {
+            Some((left, top, right, bottom))
+        } else {
+            None
         }
-        .then(|| (left, top, right, bottom))
     }
 
     #[cfg(feature = "api-level-28")]


### PR DESCRIPTION
Rust 1.64 is a bit more strict on requiring `.then_some(...)` here over `.then(|| ...)` with a closure, but the former has only been stabilized in 1.62.  No need to be cocky and bump the MSRV, replace it with an `if`-`else` like the rest of the `.exists()` path-checking code around here.
