### PR TITLE
cargo-apk: Add `strip` configuration to manifest

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -32,10 +32,10 @@
 # 0.9.0 (2022-05-07)
 
 - **Breaking:** Use `min_sdk_version` to select compiler target instead of `target_sdk_version`. ([#197](https://github.com/rust-windowing/android-ndk-rs/pull/197))
-  See <https://developer.android.com/ndk/guides/sdk-versions#minsdkversion> for more details.
+  See https://developer.android.com/ndk/guides/sdk-versions#minsdkversion for more details.
 - **Breaking:** Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
-  <https://developer.android.com/distribute/best-practices/develop/target-sdk>
+  https://developer.android.com/distribute/best-practices/develop/target-sdk
   ([#203](https://github.com/rust-windowing/android-ndk-rs/pull/203))
 - Allow manifest `package` property to be provided in `Cargo.toml`. ([#236](https://github.com/rust-windowing/android-ndk-rs/pull/236))
 - Add `MAIN` intent filter in `from_subcommand` instead of relying on a custom serialization function in `ndk-build`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
@@ -47,7 +47,7 @@
 
 - Fixed the library name in case of multiple build artifacts in the Android manifest.
 - Work around missing `libgcc` on NDK r23 beta 3 and above, by providing linker script that "redirects" to `libunwind`.
-  See <https://github.com/rust-windowing/android-ndk-rs/issues/149> and <https://github.com/rust-lang/rust/pull/85806> for more details.
+  See https://github.com/rust-windowing/android-ndk-rs/issues/149 and https://github.com/rust-lang/rust/pull/85806 for more details.
 
 # 0.8.1 (2021-08-06)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables. The environment variables take precedence over signing information in the cargo manifest. Both environment variables are required except in the case of the `dev` profile, which will fall back to the default password if `CARGO_APK_DEV_KEYSTORE_PASSWORD` is not set. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
-- Adds the `strip` option, allowing a user to specify how they want debug symbols treated after cargo has finished building, but before the shared object is copied into the APK. ([#356](https://github.com/rust-windowing/android-ndk-rs/pull/356))
+- Add the `strip` option, allowing a user to specify how they want debug symbols treated after cargo has finished building, but before the shared object is copied into the APK. ([#356](https://github.com/rust-windowing/android-ndk-rs/pull/356))
 
 (0.9.5, released on 2022-10-14, was yanked due to unintentionally bumping MSRV through the `quick-xml` crate, and breaking `cargo apk --` parsing after switching to `clap`.)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -32,10 +32,10 @@
 # 0.9.0 (2022-05-07)
 
 - **Breaking:** Use `min_sdk_version` to select compiler target instead of `target_sdk_version`. ([#197](https://github.com/rust-windowing/android-ndk-rs/pull/197))
-  See https://developer.android.com/ndk/guides/sdk-versions#minsdkversion for more details.
+  See <https://developer.android.com/ndk/guides/sdk-versions#minsdkversion> for more details.
 - **Breaking:** Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
-  https://developer.android.com/distribute/best-practices/develop/target-sdk
+  <https://developer.android.com/distribute/best-practices/develop/target-sdk>
   ([#203](https://github.com/rust-windowing/android-ndk-rs/pull/203))
 - Allow manifest `package` property to be provided in `Cargo.toml`. ([#236](https://github.com/rust-windowing/android-ndk-rs/pull/236))
 - Add `MAIN` intent filter in `from_subcommand` instead of relying on a custom serialization function in `ndk-build`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
@@ -47,7 +47,7 @@
 
 - Fixed the library name in case of multiple build artifacts in the Android manifest.
 - Work around missing `libgcc` on NDK r23 beta 3 and above, by providing linker script that "redirects" to `libunwind`.
-  See https://github.com/rust-windowing/android-ndk-rs/issues/149 and https://github.com/rust-lang/rust/pull/85806 for more details.
+  See <https://github.com/rust-windowing/android-ndk-rs/issues/149> and <https://github.com/rust-lang/rust/pull/85806> for more details.
 
 # 0.8.1 (2021-08-06)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables. The environment variables take precedence over signing information in the cargo manifest. Both environment variables are required except in the case of the `dev` profile, which will fall back to the default password if `CARGO_APK_DEV_KEYSTORE_PASSWORD` is not set. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
-- Add the `strip` option, allowing a user to specify how they want debug symbols treated after cargo has finished building, but before the shared object is copied into the APK. ([#356](https://github.com/rust-windowing/android-ndk-rs/pull/356))
+- Add `strip` option to `android` metadata, allowing a user to specify how they want debug symbols treated after cargo has finished building, but before the shared object is copied into the APK. ([#356](https://github.com/rust-windowing/android-ndk-rs/pull/356))
 
 (0.9.5, released on 2022-10-14, was yanked due to unintentionally bumping MSRV through the `quick-xml` crate, and breaking `cargo apk --` parsing after switching to `clap`.)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables. The environment variables take precedence over signing information in the cargo manifest. Both environment variables are required except in the case of the `dev` profile, which will fall back to the default password if `CARGO_APK_DEV_KEYSTORE_PASSWORD` is not set. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
+- Adds the `strip` option, allowing a user to specify how they want debug symbols treated after cargo has finished building, but before the shared object is copied into the APK. ([#356](https://github.com/rust-windowing/android-ndk-rs/pull/356))
 
 (0.9.5, released on 2022-10-14, was yanked due to unintentionally bumping MSRV through the `quick-xml` crate, and breaking `cargo apk --` parsing after switching to `clap`.)
 
@@ -34,7 +35,7 @@
   See <https://developer.android.com/ndk/guides/sdk-versions#minsdkversion> for more details.
 - **Breaking:** Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
-  https://developer.android.com/distribute/best-practices/develop/target-sdk
+  <https://developer.android.com/distribute/best-practices/develop/target-sdk>
   ([#203](https://github.com/rust-windowing/android-ndk-rs/pull/203))
 - Allow manifest `package` property to be provided in `Cargo.toml`. ([#236](https://github.com/rust-windowing/android-ndk-rs/pull/236))
 - Add `MAIN` intent filter in `from_subcommand` instead of relying on a custom serialization function in `ndk-build`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -60,7 +60,7 @@ apk_name = "myapp"
 # debug symbols are present in the `.so` file(s) produced by your build, enabling
 # https://doc.rust-lang.org/cargo/reference/profiles.html#strip or
 # https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo
-# in your cargo manifest will cause debug symbols will no longer be present
+# in your cargo manifest can cause debug symbols to no longer be present
 # in the `.so`.
 strip = "default"
 

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -45,12 +45,23 @@ assets = "path/to/assets_folder"
 # Defaults to package name.
 apk_name = "myapp"
 
-# `default` (or unspecified) - Debug symbols are not treated specially
-# `strip` - Debug symbols are stripped from the shared libraries before being
-#   copied into the APK
-# `split` - Functions the same as strip, except the debug symbols are written to
-#   the apk output directory alongside the stripped shared libraries, but with a
-#   `.dwarf` extension.
+# `default` (or unspecified) - Debug symbols, if they exist, are not treated
+#                              specially
+#
+# `strip`                    - Debug symbols are stripped from the shared
+#                              libraries before being copied into the APK
+#
+# `split`                    - Functions the same as strip, except the debug
+#                              symbols are written to the apk output directory
+#                              alongside the stripped shared libraries, but with
+#                              a `.dwarf` extension.
+#
+# Note that the `strip` and `split` options will only have an effect if the
+# debug symbols are present in the `.so` file(s) produced by your build, using
+# https://doc.rust-lang.org/cargo/reference/profiles.html#strip or
+# https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo
+# in your cargo manifest will mean the debug symbols will no longer be present
+# in the `.so`
 strip = "default"
 
 # Folder containing extra shared libraries intended to be dynamically loaded at runtime.

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -56,7 +56,7 @@ apk_name = "myapp"
 #                              alongside the stripped shared libraries, with
 #                              a `.dwarf` extension.
 #
-# Note that the `strip` and `split` options will only have an effect if the
+# Note that the `strip` and `split` options will only have an effect if
 # debug symbols are present in the `.so` file(s) produced by your build, enabling
 # https://doc.rust-lang.org/cargo/reference/profiles.html#strip or
 # https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -45,6 +45,14 @@ assets = "path/to/assets_folder"
 # Defaults to package name.
 apk_name = "myapp"
 
+# `default` (or unspecified) - Debug symbols are not treated specially
+# `strip` - Debug symbols are stripped from the shared libraries before being
+#   copied into the APK
+# `split` - Functions the same as strip, except the debug symbols are written to
+#   the apk output directory alongside the stripped shared libraries, but with a
+#   `.dwarf` extension.
+strip = "default"
+
 # Folder containing extra shared libraries intended to be dynamically loaded at runtime.
 # Files matching `libs_folder/${android_abi}/*.so` are added to the apk
 # according to the specified build_targets.

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -53,7 +53,7 @@ apk_name = "myapp"
 #
 # `split`                    - Functions the same as strip, except the debug
 #                              symbols are written to the apk output directory
-#                              alongside the stripped shared libraries, but with
+#                              alongside the stripped shared libraries, with
 #                              a `.dwarf` extension.
 #
 # Note that the `strip` and `split` options will only have an effect if the

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -51,7 +51,7 @@ apk_name = "myapp"
 # `strip`                    - Debug symbols are stripped from the shared
 #                              libraries before being copied into the APK.
 #
-# `split`                    - Functions the same as strip, except the debug
+# `split`                    - Functions the same as `strip`, except the debug
 #                              symbols are written to the apk output directory
 #                              alongside the stripped shared libraries, with
 #                              a `.dwarf` extension.

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -57,7 +57,7 @@ apk_name = "myapp"
 #                              a `.dwarf` extension.
 #
 # Note that the `strip` and `split` options will only have an effect if the
-# debug symbols are present in the `.so` file(s) produced by your build, using
+# debug symbols are present in the `.so` file(s) produced by your build, enabling
 # https://doc.rust-lang.org/cargo/reference/profiles.html#strip or
 # https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo
 # in your cargo manifest will cause debug symbols will no longer be present

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -60,7 +60,7 @@ apk_name = "myapp"
 # debug symbols are present in the `.so` file(s) produced by your build, using
 # https://doc.rust-lang.org/cargo/reference/profiles.html#strip or
 # https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo
-# in your cargo manifest will mean the debug symbols will no longer be present
+# in your cargo manifest will cause debug symbols will no longer be present
 # in the `.so`.
 strip = "default"
 

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -61,7 +61,7 @@ apk_name = "myapp"
 # https://doc.rust-lang.org/cargo/reference/profiles.html#strip or
 # https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo
 # in your cargo manifest will mean the debug symbols will no longer be present
-# in the `.so`
+# in the `.so`.
 strip = "default"
 
 # Folder containing extra shared libraries intended to be dynamically loaded at runtime.

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -46,10 +46,10 @@ assets = "path/to/assets_folder"
 apk_name = "myapp"
 
 # `default` (or unspecified) - Debug symbols, if they exist, are not treated
-#                              specially
+#                              specially.
 #
 # `strip`                    - Debug symbols are stripped from the shared
-#                              libraries before being copied into the APK
+#                              libraries before being copied into the APK.
 #
 # `split`                    - Functions the same as strip, except the debug
 #                              symbols are written to the apk output directory

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -176,6 +176,7 @@ impl<'a> ApkBuilder<'a> {
             resources,
             manifest,
             disable_aapt_compression: is_debug_profile,
+            strip: self.manifest.strip,
             reverse_port_forward: self.manifest.reverse_port_forward.clone(),
         };
         let mut apk = config.create_apk()?;

--- a/cargo-apk/src/manifest.rs
+++ b/cargo-apk/src/manifest.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use ndk_build::apk::StripConfig;
 use ndk_build::manifest::AndroidManifest;
 use ndk_build::target::Target;
 use serde::Deserialize;
@@ -18,6 +19,7 @@ pub(crate) struct Manifest {
     /// Maps profiles to keystores
     pub(crate) signing: HashMap<String, Signing>,
     pub(crate) reverse_port_forward: HashMap<String, String>,
+    pub(crate) strip: StripConfig,
 }
 
 impl Manifest {
@@ -40,6 +42,7 @@ impl Manifest {
             runtime_libs: metadata.runtime_libs,
             signing: metadata.signing,
             reverse_port_forward: metadata.reverse_port_forward,
+            strip: metadata.strip,
         })
     }
 }
@@ -76,6 +79,8 @@ struct AndroidMetadata {
     /// Set up reverse port forwarding before launching the application
     #[serde(default)]
     reverse_port_forward: HashMap<String, String>,
+    #[serde(default)]
+    strip: StripConfig,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `ndk::DEFAULT_DEV_KEYSTORE_PASSWORD` and make `apk::ApkConfig::apk` public. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
 - `RUSTFLAGS` is now considered if `CARGO_ENCODED_RUSTFLAGS` is not present allowing `cargo apk build` to not break users' builds if they depend on `RUSTFLAGS` being set prior to the build,
   as `CARGO_ENCODED_RUSTFLAGS` set by `ndk-build` before invoking `cargo` will take precedence over [all other sources of build flags](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags). ([#357](https://github.com/rust-windowing/android-ndk-rs/pull/357))
+- Adds `ApkConfig::strip`, allowing a user to specify how they want debug symbols treated after cargo has finished building, but before the shared object is copied into the APK. ([#356](https://github.com/rust-windowing/android-ndk-rs/pull/356))
 
 (0.8.1, released on 2022-10-14, was yanked due to violating semver.)
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Add `ndk::DEFAULT_DEV_KEYSTORE_PASSWORD` and make `apk::ApkConfig::apk` public. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
 - `RUSTFLAGS` is now considered if `CARGO_ENCODED_RUSTFLAGS` is not present allowing `cargo apk build` to not break users' builds if they depend on `RUSTFLAGS` being set prior to the build,
   as `CARGO_ENCODED_RUSTFLAGS` set by `ndk-build` before invoking `cargo` will take precedence over [all other sources of build flags](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags). ([#357](https://github.com/rust-windowing/android-ndk-rs/pull/357))
-- Adds `ApkConfig::strip`, allowing a user to specify how they want debug symbols treated after cargo has finished building, but before the shared object is copied into the APK. ([#356](https://github.com/rust-windowing/android-ndk-rs/pull/356))
+- Add `ApkConfig::strip`, allowing a user to specify how they want debug symbols treated after cargo has finished building, but before the shared object is copied into the APK. ([#356](https://github.com/rust-windowing/android-ndk-rs/pull/356))
 
 (0.8.1, released on 2022-10-14, was yanked due to violating semver.)
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 - **Breaking:** Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
-  https://developer.android.com/distribute/best-practices/develop/target-sdk
+  <https://developer.android.com/distribute/best-practices/develop/target-sdk>
 - **Breaking:** Remove default insertion of `MAIN` intent filter through a custom serialization function, this is better filled in by
   the default setup in `cargo-apk`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
 - Add `android:exported` attribute to the manifest's `Activity` element. ([#242](https://github.com/rust-windowing/android-ndk-rs/pull/242))

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 - **Breaking:** Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
-  <https://developer.android.com/distribute/best-practices/develop/target-sdk>
+  https://developer.android.com/distribute/best-practices/develop/target-sdk
 - **Breaking:** Remove default insertion of `MAIN` intent filter through a custom serialization function, this is better filled in by
   the default setup in `cargo-apk`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
 - Add `android:exported` attribute to the manifest's `Activity` element. ([#242](https://github.com/rust-windowing/android-ndk-rs/pull/242))

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -9,17 +9,22 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StripConfig {
     /// Matches the current behavior to not do anything to the native library
-    #[default]
     Default,
     /// Removes debug symbols from the library before copying it into the APK
     Strip,
     /// Splits the library into into an ELF (.so) and DWARF (.dwarf). Only the
     /// .so is copied into the APK
     Split,
+}
+
+impl Default for StripConfig {
+    fn default() -> Self {
+        Self::Default
+    }
 }
 
 pub struct ApkConfig {

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -9,10 +9,17 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// The options for how to treat debug symbols that are present in any `.so`
+/// files that are added to the APK.
+///
+/// Using [strip](https://doc.rust-lang.org/cargo/reference/profiles.html#strip)
+/// or [split-debuginfo](https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo)
+/// in your cargo manifest(s) may cause debug symbols to not be present in an
+/// `.so`, which would cause these options to do nothing
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StripConfig {
-    /// Does not treat debug symbols especially
+    /// Does not treat debug symbols specially
     Default,
     /// Removes debug symbols from the library before copying it into the APK
     Strip,

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -14,8 +14,8 @@ use std::process::Command;
 ///
 /// Using [strip](https://doc.rust-lang.org/cargo/reference/profiles.html#strip)
 /// or [split-debuginfo](https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo)
-/// in your cargo manifest(s) may cause debug symbols to not be present in an
-/// `.so`, which would cause these options to do nothing
+/// in your cargo manifest(s) may cause debug symbols to not be present in a
+/// `.so`, which would cause these options to do nothing.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StripConfig {

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -9,6 +9,19 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StripConfig {
+    /// Matches the current behavior to not do anything to the native library
+    #[default]
+    Default,
+    /// Removes debug symbols from the library before copying it into the APK
+    Strip,
+    /// Splits the library into into an ELF (.so) and DWARF (.dwarf). Only the
+    /// .so is copied into the APK
+    Split,
+}
+
 pub struct ApkConfig {
     pub ndk: Ndk,
     pub build_dir: PathBuf,
@@ -17,6 +30,7 @@ pub struct ApkConfig {
     pub resources: Option<PathBuf>,
     pub manifest: AndroidManifest,
     pub disable_aapt_compression: bool,
+    pub strip: StripConfig,
     pub reverse_port_forward: HashMap<String, String>,
 }
 

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -100,16 +100,6 @@ pub struct UnalignedApk<'a> {
     pending_libs: HashSet<String>,
 }
 
-macro_rules! timeit {
-    ($name:expr, $op:block) => {
-        let start = std::time::Instant::now();
-
-        $op
-
-        eprintln!("{} completed in {:.2}s", $name, start.elapsed().as_secs_f32());
-    }
-}
-
 impl<'a> UnalignedApk<'a> {
     pub fn config(&self) -> &ApkConfig {
         self.config
@@ -131,7 +121,7 @@ impl<'a> UnalignedApk<'a> {
             StripConfig::Strip | StripConfig::Split => {
                 let obj_copy = self.config.ndk.toolchain_bin("objcopy", target)?;
 
-                timeit!(format!("strip debuginfo from {}", lib_path.display()), {
+                {
                     let mut cmd = Command::new(&obj_copy);
                     cmd.current_dir(&self.config.build_dir);
                     cmd.arg("--strip-debug");
@@ -141,7 +131,7 @@ impl<'a> UnalignedApk<'a> {
                     if !cmd.status()?.success() {
                         return Err(NdkError::CmdFailed(cmd));
                     }
-                });
+                }
 
                 if self.config.strip == StripConfig::Split {
                     let dwarf_path = {
@@ -150,7 +140,7 @@ impl<'a> UnalignedApk<'a> {
                         dp
                     };
 
-                    timeit!(format!("write {}", dwarf_path.display()), {
+                    {
                         let mut cmd = Command::new(&obj_copy);
                         cmd.current_dir(&self.config.build_dir);
                         cmd.arg("--only-keep-debug");
@@ -160,7 +150,7 @@ impl<'a> UnalignedApk<'a> {
                         if !cmd.status()?.success() {
                             return Err(NdkError::CmdFailed(cmd));
                         }
-                    });
+                    }
 
                     let mut cmd = Command::new(obj_copy);
                     cmd.current_dir(&self.config.build_dir);
@@ -215,11 +205,9 @@ impl<'a> UnalignedApk<'a> {
             aapt.arg(lib_path_unix);
         }
 
-        timeit!("write APK", {
-            if !aapt.status()?.success() {
-                return Err(NdkError::CmdFailed(aapt));
-            }
-        });
+        if !aapt.status()?.success() {
+            return Err(NdkError::CmdFailed(aapt));
+        }
 
         let mut zipalign = self.config.build_tool(bin!("zipalign"))?;
         zipalign
@@ -229,11 +217,9 @@ impl<'a> UnalignedApk<'a> {
             .arg(self.config.unaligned_apk())
             .arg(self.config.apk());
 
-        timeit!(format!("align {}", self.config.apk().display()), {
-            if !zipalign.status()?.success() {
-                return Err(NdkError::CmdFailed(zipalign));
-            }
-        });
+        if !zipalign.status()?.success() {
+            return Err(NdkError::CmdFailed(zipalign));
+        }
 
         Ok(UnsignedApk(self.config))
     }

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -12,8 +12,8 @@ use std::process::Command;
 /// The options for how to treat debug symbols that are present in any `.so`
 /// files that are added to the APK.
 ///
-/// Using [strip](https://doc.rust-lang.org/cargo/reference/profiles.html#strip)
-/// or [split-debuginfo](https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo)
+/// Using [`strip`](https://doc.rust-lang.org/cargo/reference/profiles.html#strip)
+/// or [`split-debuginfo`](https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo)
 /// in your cargo manifest(s) may cause debug symbols to not be present in a
 /// `.so`, which would cause these options to do nothing.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize)]

--- a/ndk-build/src/cargo.rs
+++ b/ndk-build/src/cargo.rs
@@ -47,7 +47,7 @@ pub fn cargo_ndk(
             }
         }
         Err(std::env::VarError::NotUnicode(_)) => {
-            panic!("RUSTFLAGS environment variable contains non-unicode characters")
+            panic!("CARGO_ENCODED_RUSTFLAGS environment variable contains non-unicode characters")
         }
     };
 

--- a/ndk-build/src/cargo.rs
+++ b/ndk-build/src/cargo.rs
@@ -47,7 +47,7 @@ pub fn cargo_ndk(
             }
         }
         Err(std::env::VarError::NotUnicode(_)) => {
-            panic!("CARGO_ENCODED_RUSTFLAGS environment variable contains non-unicode characters")
+            panic!("RUSTFLAGS environment variable contains non-unicode characters")
         }
     };
 


### PR DESCRIPTION
I've been extremely annoyed with the time that `cargo-apk` adds onto our build for a long time and today was the day that I got annoyed enough to fix it.

This PR adds a configuration field, `package.metadata.android.strip` that allows users to configure how they want to treat debug symbols _after_ cargo build has finished, but _before_ the .so libraries are appended to the APK.

- `default` - This acts the exact same as the current version of cargo-apk, and is the value used if `strip` is not explicitly set. The .so produced by cargo is simply copied to the `apk` output directory with no modification.
- `strip` - The library copied into the apk output directory is stripped of debug symbols
- `split` - The library copied into the apk output directory is stripped of debug symbols, in addition, the debug symbols are copied into the directory as well with the same filename as the library, but a `.dwarf` extension.

#355 was closed with the suggestion to just use the [strip](https://doc.rust-lang.org/cargo/reference/profiles.html#strip) option in cargo, but unfortunately that doesn't work for our use case. We absolutely do want debug symbols, since we upload all debug symbols to our symbol server so that we can either use them for debugging, or most likely, as the source for the debugging information our error/crash reporting system uses to resolve symbolicated stack traces. Using `strip` to remove debug info is therefore not an option for us, and unfortunately [`split-debuginfo`](https://doc.rust-lang.org/rustc/codegen-options/index.html#split-debuginfo) doesn't actually do anything when targeting android, at least at the moment. That being said I think this option still makes sense once `split-debuginfo` does work for android, since it keeps the split symbols next to the library they are paired with, which makes it nicer for any tooling that is doing any kind of processing to handle them, as otherwise they would need to look in the regular target dir as well as the apk dir.

This change make our Android release step, which currently produces ~2.4GiB of DWARF debug data, go from a ridiculous +3m30s (surpassing the time it actually takes the code to build!) to a more reasonable (though still not good) +17s to strip debug symbols and write the stripped binaries and other things to the APK.