### PR TITLE
nkd-build: Propagate `RUSTFLAGS` into `CARGO_ENCODED_RUSTFLAGS`

### DIFF
--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Add `ndk::DEFAULT_DEV_KEYSTORE_PASSWORD` and make `apk::ApkConfig::apk` public. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
+- `RUSTFLAGS` is now considered if `CARGO_ENCODED_RUSTFLAGS` is not present, this allows `cargo apk build` to not break user's builds if they depend on flags being set on the build, as `CARGO_ENCODED_RUSTFLAGS`, set by `ndk-build` before invoking cargo, will take precedence over all other sources of build flags. ([#357](https://github.com/rust-windowing/android-ndk-rs/pull/357))
 
 (0.8.1, released on 2022-10-14, was yanked due to violating semver.)
 
@@ -34,7 +35,7 @@
 
 - **Breaking:** Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
-  https://developer.android.com/distribute/best-practices/develop/target-sdk
+  <https://developer.android.com/distribute/best-practices/develop/target-sdk>
 - **Breaking:** Remove default insertion of `MAIN` intent filter through a custom serialization function, this is better filled in by
   the default setup in `cargo-apk`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
 - Add `android:exported` attribute to the manifest's `Activity` element. ([#242](https://github.com/rust-windowing/android-ndk-rs/pull/242))

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - Add `ndk::DEFAULT_DEV_KEYSTORE_PASSWORD` and make `apk::ApkConfig::apk` public. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
-- `RUSTFLAGS` is now considered if `CARGO_ENCODED_RUSTFLAGS` is not present, this allows `cargo apk build` to not break user's builds if they depend on flags being set on the build, as `CARGO_ENCODED_RUSTFLAGS`, set by `ndk-build` before invoking cargo, will take precedence over all other sources of build flags. ([#357](https://github.com/rust-windowing/android-ndk-rs/pull/357))
+- `RUSTFLAGS` is now considered if `CARGO_ENCODED_RUSTFLAGS` is not present allowing `cargo apk build` to not break users' builds if they depend on `RUSTFLAGS` being set prior to the build, as `CARGO_ENCODED_RUSTFLAGS` set by `ndk-build` before invoking `cargo` will take precedence over all other sources of build flags (https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags). ([#357](https://github.com/rust-windowing/android-ndk-rs/pull/357))
 
 (0.8.1, released on 2022-10-14, was yanked due to violating semver.)
 

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add `ndk::DEFAULT_DEV_KEYSTORE_PASSWORD` and make `apk::ApkConfig::apk` public. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
 - `RUSTFLAGS` is now considered if `CARGO_ENCODED_RUSTFLAGS` is not present allowing `cargo apk build` to not break users' builds if they depend on `RUSTFLAGS` being set prior to the build,
-  as `CARGO_ENCODED_RUSTFLAGS` set by `ndk-build` before invoking `cargo` will take precedence over all other sources of [build flags](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags). ([#357](https://github.com/rust-windowing/android-ndk-rs/pull/357))
+  as `CARGO_ENCODED_RUSTFLAGS` set by `ndk-build` before invoking `cargo` will take precedence over [all other sources of build flags](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags). ([#357](https://github.com/rust-windowing/android-ndk-rs/pull/357))
 
 (0.8.1, released on 2022-10-14, was yanked due to violating semver.)
 
@@ -36,7 +36,7 @@
 
 - **Breaking:** Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
-  https://developer.android.com/distribute/best-practices/develop/target-sdk
+  <https://developer.android.com/distribute/best-practices/develop/target-sdk>
 - **Breaking:** Remove default insertion of `MAIN` intent filter through a custom serialization function, this is better filled in by
   the default setup in `cargo-apk`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
 - Add `android:exported` attribute to the manifest's `Activity` element. ([#242](https://github.com/rust-windowing/android-ndk-rs/pull/242))

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 - Add `ndk::DEFAULT_DEV_KEYSTORE_PASSWORD` and make `apk::ApkConfig::apk` public. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
-- `RUSTFLAGS` is now considered if `CARGO_ENCODED_RUSTFLAGS` is not present allowing `cargo apk build` to not break users' builds if they depend on `RUSTFLAGS` being set prior to the build, as `CARGO_ENCODED_RUSTFLAGS` set by `ndk-build` before invoking `cargo` will take precedence over all other sources of build flags (https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags). ([#357](https://github.com/rust-windowing/android-ndk-rs/pull/357))
+- `RUSTFLAGS` is now considered if `CARGO_ENCODED_RUSTFLAGS` is not present allowing `cargo apk build` to not break users' builds if they depend on `RUSTFLAGS` being set prior to the build,
+  as `CARGO_ENCODED_RUSTFLAGS` set by `ndk-build` before invoking `cargo` will take precedence over all other sources of [build flags](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags). ([#357](https://github.com/rust-windowing/android-ndk-rs/pull/357))
 
 (0.8.1, released on 2022-10-14, was yanked due to violating semver.)
 
@@ -35,7 +36,7 @@
 
 - **Breaking:** Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
-  <https://developer.android.com/distribute/best-practices/develop/target-sdk>
+  https://developer.android.com/distribute/best-practices/develop/target-sdk
 - **Breaking:** Remove default insertion of `MAIN` intent filter through a custom serialization function, this is better filled in by
   the default setup in `cargo-apk`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
 - Add `android:exported` attribute to the manifest's `Activity` element. ([#242](https://github.com/rust-windowing/android-ndk-rs/pull/242))

--- a/ndk-build/src/cargo.rs
+++ b/ndk-build/src/cargo.rs
@@ -16,7 +16,7 @@ pub fn cargo_ndk(
 
     const SEP: char = '\x1f';
 
-    // Read initial RUSTFLAGS
+    // Read initial CARGO_ENCODED_/RUSTFLAGS
     let mut rustflags = match std::env::var("CARGO_ENCODED_RUSTFLAGS") {
         Ok(val) => val,
         Err(std::env::VarError::NotPresent) => {
@@ -26,20 +26,15 @@ pub fn cargo_ndk(
                     // https://github.com/rust-lang/cargo/blob/f6de921a5d807746e972d9d10a4d8e1ca21e1b1f/src/cargo/core/compiler/build_context/target_info.rs#L682-L690
                     let mut rf = String::with_capacity(val.len());
                     if !val.is_empty() {
-                        for arg in val.split(' ').filter_map(|s| {
-                            let s = s.trim();
-                            if !s.is_empty() {
-                                Some(s)
-                            } else {
-                                None
-                            }
-                        }) {
+                        for arg in val.split(' ').map(|s| s.trim()).filter(|s| !s.is_empty()) {
                             rf.push_str(arg);
                             rf.push(SEP);
                         }
 
                         rf.pop();
                     }
+
+                    cargo.env_remove("RUSTFLAGS");
 
                     rf
                 }

--- a/ndk-build/src/cargo.rs
+++ b/ndk-build/src/cargo.rs
@@ -30,18 +30,15 @@ pub fn cargo_ndk(
         Err(std::env::VarError::NotPresent) => {
             match std::env::var("RUSTFLAGS") {
                 Ok(val) => {
-                    // Note cargo also does this very simplified parsing of only
-                    // splitting on spaces, ignoring things like quoting
-                    // https://github.com/rust-lang/cargo/blob/f6de921a5d807746e972d9d10a4d8e1ca21e1b1f/src/cargo/core/compiler/build_context/target_info.rs#L682-L690
-                    let to_join: Vec<_> = val
-                        .split(' ')
-                        .map(|s| s.trim())
-                        .filter(|s| !s.is_empty())
-                        .collect();
-
                     cargo.env_remove("RUSTFLAGS");
 
-                    to_join.join(SEP)
+                    // Same as cargo
+                    // https://github.com/rust-lang/cargo/blob/f6de921a5d807746e972d9d10a4d8e1ca21e1b1f/src/cargo/core/compiler/build_context/target_info.rs#L682-L690
+                    val.split(' ')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(SEP)
                 }
                 Err(std::env::VarError::NotPresent) => String::new(),
                 Err(std::env::VarError::NotUnicode(_)) => {

--- a/ndk-build/src/cargo.rs
+++ b/ndk-build/src/cargo.rs
@@ -18,7 +18,15 @@ pub fn cargo_ndk(
 
     // Read initial CARGO_ENCODED_/RUSTFLAGS
     let mut rustflags = match std::env::var("CARGO_ENCODED_RUSTFLAGS") {
-        Ok(val) => val,
+        Ok(val) => {
+            if std::env::var_os("RUSTFLAGS").is_some() {
+                panic!(
+                    "Both `CARGO_ENCODED_RUSTFLAGS` and `RUSTFLAGS` were found in the environment, please clear one or the other before invoking this script"
+                );
+            }
+
+            val
+        }
         Err(std::env::VarError::NotPresent) => {
             match std::env::var("RUSTFLAGS") {
                 Ok(val) => {

--- a/ndk-build/src/cargo.rs
+++ b/ndk-build/src/cargo.rs
@@ -14,7 +14,7 @@ pub fn cargo_ndk(
     let clang_target = format!("--target={}{}", target.ndk_llvm_triple(), sdk_version);
     let mut cargo = Command::new("cargo");
 
-    const SEP: char = '\x1f';
+    const SEP: &str = "\x1f";
 
     // Read initial CARGO_ENCODED_/RUSTFLAGS
     let mut rustflags = match std::env::var("CARGO_ENCODED_RUSTFLAGS") {
@@ -41,7 +41,7 @@ pub fn cargo_ndk(
 
                     cargo.env_remove("RUSTFLAGS");
 
-                    to_join.join("\x1f")
+                    to_join.join(SEP)
                 }
                 Err(std::env::VarError::NotPresent) => String::new(),
                 Err(std::env::VarError::NotUnicode(_)) => {
@@ -67,7 +67,7 @@ pub fn cargo_ndk(
     // https://doc.rust-lang.org/beta/cargo/reference/environment-variables.html#configuration-environment-variables
     cargo.env(cargo_env_target_cfg("LINKER", triple), &clang);
     if !rustflags.is_empty() {
-        rustflags.push(SEP);
+        rustflags.push_str(SEP);
     }
     rustflags.push_str("-Clink-arg=");
     rustflags.push_str(&clang_target);
@@ -98,9 +98,9 @@ pub fn cargo_ndk(
         // suggests to resort to RUSTFLAGS.
         // Note that `rustflags` will never be empty because of an unconditional `.push_str` above,
         // so we can safely start with appending \x1f here.
-        rustflags.push(SEP);
+        rustflags.push_str(SEP);
         rustflags.push_str("-L");
-        rustflags.push(SEP);
+        rustflags.push_str(SEP);
         rustflags.push_str(
             cargo_apk_link_dir
                 .to_str()

--- a/ndk-build/src/cargo.rs
+++ b/ndk-build/src/cargo.rs
@@ -30,21 +30,18 @@ pub fn cargo_ndk(
         Err(std::env::VarError::NotPresent) => {
             match std::env::var("RUSTFLAGS") {
                 Ok(val) => {
-                    // Note this is roughly equivalent to what cargo does
+                    // Note cargo also does this very simplified parsing of only
+                    // splitting on spaces, ignoring things like quoting
                     // https://github.com/rust-lang/cargo/blob/f6de921a5d807746e972d9d10a4d8e1ca21e1b1f/src/cargo/core/compiler/build_context/target_info.rs#L682-L690
-                    let mut rf = String::with_capacity(val.len());
-                    if !val.is_empty() {
-                        for arg in val.split(' ').map(|s| s.trim()).filter(|s| !s.is_empty()) {
-                            rf.push_str(arg);
-                            rf.push(SEP);
-                        }
-
-                        rf.pop();
-                    }
+                    let to_join: Vec<_> = val
+                        .split(' ')
+                        .map(|s| s.trim())
+                        .filter(|s| !s.is_empty())
+                        .collect();
 
                     cargo.env_remove("RUSTFLAGS");
 
-                    rf
+                    to_join.join("\x1f")
                 }
                 Err(std::env::VarError::NotPresent) => String::new(),
                 Err(std::env::VarError::NotUnicode(_)) => {


### PR DESCRIPTION
When running the actual cargo build, the `CARGO_ENCODED_RUSTFLAGS` was being read so that the rustflags set by the user are not overwritten when cargo-apk is adding its flags. However, this environment variable will only be set if you are building the APK via a build script, if you are invoking `cargo apk build` cargo will not create that environment variable since it doesn't know what actual target/profile is going to be built. If `CARGO_ENCODED_RUSTFLAGS` is not found, this change now falls back to `RUSTFLAGS`, and interprets it the same as `cargo` does before writing it in the encoded form expected by `CARGO_ENCODED_RUSTFLAGS`