### PR TITLE
Read keystore path/password from env vars prior to package metadata

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables. The environment variables take precedence over signing information in the cargo manifest. Both environment variables are required except in the case of the `dev` profile, which will fall back to the default password if the `CARGO_APK_DEV_KEYSTORE_PASSWORD` is not set. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
+- Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables. The environment variables take precedence over signing information in the cargo manifest. Both environment variables are required except in the case of the `dev` profile, which will fall back to the default password if `CARGO_APK_DEV_KEYSTORE_PASSWORD` is not set. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
 
 (0.9.5, released on 2022-10-14, was yanked due to unintentionally bumping MSRV through the `quick-xml` crate, and breaking `cargo apk --` parsing after switching to `clap`.)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables if the signing information isn't present in the cargo manifest. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
+- Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables. The environment variables take precedence over signing information the cargo manifest. Both environment variables are required except in the case of the `dev` profile, which will fallback to the default password if the `CARGO_APK_DEV_KEYSTORE_PASSWORD` is not set. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
 
 (0.9.5, released on 2022-10-14, was yanked due to unintentionally bumping MSRV through the `quick-xml` crate, and breaking `cargo apk --` parsing after switching to `clap`.)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- The `path` component of the profile signing is now optional, if not specified the `CARGO_APK_<PROFILE>_KEYSTORE` environment variable is read to determine the path to the keystore. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
+
 (0.9.5, released on 2022-10-14, was yanked due to unintentionally bumping MSRV through the `quick-xml` crate, and breaking `cargo apk --` parsing after switching to `clap`.)
 
 - Automate `adb reverse` port forwarding through `Cargo.toml` metadata ([#348](https://github.com/rust-windowing/android-ndk-rs/pull/348))
@@ -29,10 +31,10 @@
 # 0.9.0 (2022-05-07)
 
 - **Breaking:** Use `min_sdk_version` to select compiler target instead of `target_sdk_version`. ([#197](https://github.com/rust-windowing/android-ndk-rs/pull/197))
-  See https://developer.android.com/ndk/guides/sdk-versions#minsdkversion for more details.
+  See <https://developer.android.com/ndk/guides/sdk-versions#minsdkversion> for more details.
 - **Breaking:** Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
-  https://developer.android.com/distribute/best-practices/develop/target-sdk
+  <https://developer.android.com/distribute/best-practices/develop/target-sdk>
   ([#203](https://github.com/rust-windowing/android-ndk-rs/pull/203))
 - Allow manifest `package` property to be provided in `Cargo.toml`. ([#236](https://github.com/rust-windowing/android-ndk-rs/pull/236))
 - Add `MAIN` intent filter in `from_subcommand` instead of relying on a custom serialization function in `ndk-build`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))
@@ -44,7 +46,7 @@
 
 - Fixed the library name in case of multiple build artifacts in the Android manifest.
 - Work around missing `libgcc` on NDK r23 beta 3 and above, by providing linker script that "redirects" to `libunwind`.
-  See https://github.com/rust-windowing/android-ndk-rs/issues/149 and https://github.com/rust-lang/rust/pull/85806 for more details.
+  See <https://github.com/rust-windowing/android-ndk-rs/issues/149> and <https://github.com/rust-lang/rust/pull/85806> for more details.
 
 # 0.8.1 (2021-08-06)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Non-dev profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables if the signing information isn't present in the cargo manifest. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
+- Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables if the signing information isn't present in the cargo manifest. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
 
 (0.9.5, released on 2022-10-14, was yanked due to unintentionally bumping MSRV through the `quick-xml` crate, and breaking `cargo apk --` parsing after switching to `clap`.)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables. The environment variables take precedence over signing information the cargo manifest. Both environment variables are required except in the case of the `dev` profile, which will fallback to the default password if the `CARGO_APK_DEV_KEYSTORE_PASSWORD` is not set. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
+- Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables. The environment variables take precedence over signing information in the cargo manifest. Both environment variables are required except in the case of the `dev` profile, which will fall back to the default password if the `CARGO_APK_DEV_KEYSTORE_PASSWORD` is not set. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
 
 (0.9.5, released on 2022-10-14, was yanked due to unintentionally bumping MSRV through the `quick-xml` crate, and breaking `cargo apk --` parsing after switching to `clap`.)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- The `path` component of the profile signing is now optional, if not specified the `CARGO_APK_<PROFILE>_KEYSTORE` environment variable is read to determine the path to the keystore. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
+- Non-dev profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables if the signing information isn't present in the cargo manifest. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
 
 (0.9.5, released on 2022-10-14, was yanked due to unintentionally bumping MSRV through the `quick-xml` crate, and breaking `cargo apk --` parsing after switching to `clap`.)
 

--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -34,7 +34,7 @@
   See <https://developer.android.com/ndk/guides/sdk-versions#minsdkversion> for more details.
 - **Breaking:** Default `target_sdk_version` to `30` or lower (instead of the highest supported SDK version by the detected NDK toolchain)
   for more consistent interaction with Android backwards compatibility handling and its increasingly strict usage rules:
-  <https://developer.android.com/distribute/best-practices/develop/target-sdk>
+  https://developer.android.com/distribute/best-practices/develop/target-sdk
   ([#203](https://github.com/rust-windowing/android-ndk-rs/pull/203))
 - Allow manifest `package` property to be provided in `Cargo.toml`. ([#236](https://github.com/rust-windowing/android-ndk-rs/pull/236))
 - Add `MAIN` intent filter in `from_subcommand` instead of relying on a custom serialization function in `ndk-build`. ([#241](https://github.com/rust-windowing/android-ndk-rs/pull/241))

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -50,16 +50,17 @@ apk_name = "myapp"
 # according to the specified build_targets.
 runtime_libs = "path/to/libs_folder"
 
-# Defaults to `$HOME/.android/debug.keystore` for the `dev` profile. Will ONLY generate a new
-# debug.keystore if this file does NOT exist. A keystore is never auto-generated
-# for other profiles.
+# Defaults to `$HOME/.android/debug.keystore` for the `dev` profile. Will ONLY
+# generate a new debug.keystore if this file does NOT exist. A keystore is never
+# auto-generated for other profiles.
 #
 # If specified, the keystore path can be absolute, or relative to the Cargo.toml
-# file. If not specified, the environment variable `CARGO_APK_<PROFILE>_KEYSTORE`
-# environment variable is read. The profile portion follows the same rules as
-# `<cfg>`, it is the uppercased profile name with `-` replaced with `_`.
+# file. If not specified, the environment variables `CARGO_APK_<PROFILE>_KEYSTORE`
+# `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` are read to retrieve the keystore path
+# and keystore password respectively. The profile portion follows the same rules
+# as `<cfg>`, it is the uppercased profile name with `-` replaced with `_`.
 [package.metadata.android.signing.<profile>]
-path = "relative/or/absolute/path/my.keystore"
+path = "relative/or/absolute/path/to/my.keystore"
 keystore_password = "android"
 
 # See https://developer.android.com/guide/topics/manifest/uses-sdk-element

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -52,9 +52,12 @@ runtime_libs = "path/to/libs_folder"
 
 # Defaults to `$HOME/.android/debug.keystore` for the `dev` profile. Will ONLY generate a new
 # debug.keystore if this file does NOT exist.
-# A keystore path is always required on the `release` profile.
+# If specified, the keystore path is a path relative to the Cargo.toml file, if
+# not specified, the environment variable `CARGO_APK_<PROFILE>_KEYSTORE` env
+# variable is read. The profile portion follows the same rules as <cfg>, it is
+# the uppercased profile name with `-` replaced with `_`.
 [package.metadata.android.signing.<profile>]
-path = "$HOME/.android/debug.keystore"
+path = "relative/path/my.keystore"
 keystore_password = "android"
 
 # See https://developer.android.com/guide/topics/manifest/uses-sdk-element

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -54,11 +54,14 @@ runtime_libs = "path/to/libs_folder"
 # generate a new debug.keystore if this file does NOT exist. A keystore is never
 # auto-generated for other profiles.
 #
-# If specified, the keystore path can be absolute, or relative to the Cargo.toml
-# file. If not specified, the environment variables `CARGO_APK_<PROFILE>_KEYSTORE`
-# `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` are read to retrieve the keystore path
+# The keystore path can be absolute, or relative to the Cargo.toml file.
+#
+# The environment variables `CARGO_APK_<PROFILE>_KEYSTORE` and
+# `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` can be read to retrieve the keystore path
 # and keystore password respectively. The profile portion follows the same rules
 # as `<cfg>`, it is the uppercased profile name with `-` replaced with `_`.
+#
+# If present they take precedence over the signing information in the manifest. 
 [package.metadata.android.signing.<profile>]
 path = "relative/or/absolute/path/to/my.keystore"
 keystore_password = "android"

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -57,7 +57,7 @@ runtime_libs = "path/to/libs_folder"
 # The keystore path can be absolute, or relative to the Cargo.toml file.
 #
 # The environment variables `CARGO_APK_<PROFILE>_KEYSTORE` and
-# `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` can be configured/set to the keystore path
+# `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` can be set to a keystore path
 # and keystore password respectively. The profile portion follows the same rules
 # as `<cfg>`, it is the uppercased profile name with `-` replaced with `_`.
 #

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -57,7 +57,7 @@ runtime_libs = "path/to/libs_folder"
 # The keystore path can be absolute, or relative to the Cargo.toml file.
 #
 # The environment variables `CARGO_APK_<PROFILE>_KEYSTORE` and
-# `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` can be read to retrieve the keystore path
+# `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` can be configured/set to the keystore path
 # and keystore password respectively. The profile portion follows the same rules
 # as `<cfg>`, it is the uppercased profile name with `-` replaced with `_`.
 #

--- a/cargo-apk/README.md
+++ b/cargo-apk/README.md
@@ -51,13 +51,15 @@ apk_name = "myapp"
 runtime_libs = "path/to/libs_folder"
 
 # Defaults to `$HOME/.android/debug.keystore` for the `dev` profile. Will ONLY generate a new
-# debug.keystore if this file does NOT exist.
-# If specified, the keystore path is a path relative to the Cargo.toml file, if
-# not specified, the environment variable `CARGO_APK_<PROFILE>_KEYSTORE` env
-# variable is read. The profile portion follows the same rules as <cfg>, it is
-# the uppercased profile name with `-` replaced with `_`.
+# debug.keystore if this file does NOT exist. A keystore is never auto-generated
+# for other profiles.
+#
+# If specified, the keystore path can be absolute, or relative to the Cargo.toml
+# file. If not specified, the environment variable `CARGO_APK_<PROFILE>_KEYSTORE`
+# environment variable is read. The profile portion follows the same rules as
+# `<cfg>`, it is the uppercased profile name with `-` replaced with `_`.
 [package.metadata.android.signing.<profile>]
-path = "relative/path/my.keystore"
+path = "relative/or/absolute/path/my.keystore"
 keystore_password = "android"
 
 # See https://developer.android.com/guide/topics/manifest/uses-sdk-element

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -241,7 +241,7 @@ impl<'a> ApkBuilder<'a> {
                 );
                 Key {
                     path,
-                    password: ndk_build::ndk::DEFAULT_DEV_PASSWORD.to_owned(),
+                    password: ndk_build::ndk::DEFAULT_DEV_KEYSTORE_PASSWORD.to_owned(),
                 }
             }
             (_, _) => {
@@ -261,7 +261,7 @@ impl<'a> ApkBuilder<'a> {
         let unsigned = apk.add_pending_libs_and_align()?;
 
         println!(
-            "Signing '{}' with keystore '{}'",
+            "Signing `{}` with keystore `{}`",
             config.apk().display(),
             signing_key.path.display()
         );

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -230,9 +230,10 @@ impl<'a> ApkBuilder<'a> {
                 let path = if let Some(path) = &signing.path {
                     crate_path.join(path)
                 } else {
-                    let profile = profile_name.to_uppercase();
-                    let profile = profile.replace('-', "_");
-                    let profile_env = format!("CARGO_APK_{profile}_KEYSTORE");
+                    let profile_env = format!(
+                        "CARGO_APK_{}_KEYSTORE",
+                        profile.to_uppercase().replace('-', "_")
+                    );
 
                     let path = std::env::var_os(&profile_env)
                         .ok_or_else(|| Error::MissingReleaseKey(profile_name.to_owned()))?;

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -223,46 +223,49 @@ impl<'a> ApkBuilder<'a> {
             Profile::Custom(c) => c.as_str(),
         };
 
-        let signing_key = self.manifest.signing.get(profile_name);
+        let keystore_env = format!(
+            "CARGO_APK_{}_KEYSTORE",
+            profile_name.to_uppercase().replace('-', "_")
+        );
+        let password_env = format!("{}_PASSWORD", keystore_env);
 
-        let signing_key = if let Some(signing) = signing_key {
-            Key {
-                path: crate_path.join(&signing.path),
-                password: signing.keystore_password.clone(),
-            }
-        } else {
-            let env_profile_name = profile_name.to_uppercase().replace('-', "_");
+        let path = std::env::var_os(&keystore_env).map(PathBuf::from);
+        let password = std::env::var(&password_env).ok();
 
-            let path = {
-                let profile_env = format!("CARGO_APK_{}_KEYSTORE", env_profile_name);
-                std::env::var_os(&profile_env).map(PathBuf::from)
-            };
-
-            let password = {
-                let profile_env = format!(
-                    "CARGO_APK_{}_KEYSTORE_PASSWORD",
-                    profile_name.to_uppercase().replace('-', "_")
+        let signing_key = match (path, password) {
+            (Some(path), Some(password)) => Key { path, password },
+            (Some(path), None) if is_debug_profile => {
+                eprintln!(
+                    "{} not specified, falling back to default password",
+                    password_env
                 );
-
-                std::env::var(&profile_env).ok()
-            };
-
-            if is_debug_profile {
-                if let (Some(path), Some(password)) = (path, password) {
-                    Key { path, password }
-                } else {
-                    self.ndk.debug_key()?
-                }
-            } else {
                 Key {
-                    path: path.ok_or_else(|| Error::MissingReleaseKey(profile_name.to_owned()))?,
-                    password: password
-                        .ok_or_else(|| Error::MissingReleaseKey(profile_name.to_owned()))?,
+                    path,
+                    password: ndk_build::ndk::DEFAULT_DEV_PASSWORD.to_owned(),
+                }
+            }
+            (_, _) => {
+                if let Some(msk) = self.manifest.signing.get(profile_name) {
+                    Key {
+                        path: crate_path.join(&msk.path),
+                        password: msk.keystore_password.clone(),
+                    }
+                } else if is_debug_profile {
+                    self.ndk.debug_key()?
+                } else {
+                    return Err(Error::MissingReleaseKey(profile_name.to_owned()));
                 }
             }
         };
 
-        Ok(apk.add_pending_libs_and_align()?.sign(signing_key)?)
+        let unsigned = apk.add_pending_libs_and_align()?;
+
+        println!(
+            "Signing '{}' with keystore '{}'",
+            config.apk().display(),
+            signing_key.path.display()
+        );
+        Ok(unsigned.sign(signing_key)?)
     }
 
     pub fn run(&self, artifact: &Artifact, no_logcat: bool) -> Result<(), Error> {

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -232,7 +232,7 @@ impl<'a> ApkBuilder<'a> {
                 } else {
                     let profile_env = format!(
                         "CARGO_APK_{}_KEYSTORE",
-                        profile.to_uppercase().replace('-', "_")
+                        profile_name.to_uppercase().replace('-', "_")
                     );
 
                     let path = std::env::var_os(&profile_env)

--- a/cargo-apk/src/apk.rs
+++ b/cargo-apk/src/apk.rs
@@ -244,7 +244,11 @@ impl<'a> ApkBuilder<'a> {
                     password: ndk_build::ndk::DEFAULT_DEV_KEYSTORE_PASSWORD.to_owned(),
                 }
             }
-            (_, _) => {
+            (Some(path), None) => {
+                eprintln!("`{}` was specified via `{}`, but `{}` was not specified, both or neither must be present for profiles other than `dev`", path.display(), keystore_env, password_env);
+                return Err(Error::MissingReleaseKey(profile_name.to_owned()));
+            }
+            (None, _) => {
                 if let Some(msk) = self.manifest.signing.get(profile_name) {
                     Key {
                         path: crate_path.join(&msk.path),

--- a/cargo-apk/src/manifest.rs
+++ b/cargo-apk/src/manifest.rs
@@ -80,6 +80,6 @@ struct AndroidMetadata {
 
 #[derive(Clone, Debug, Default, Deserialize)]
 pub(crate) struct Signing {
-    pub(crate) path: Option<PathBuf>,
+    pub(crate) path: PathBuf,
     pub(crate) keystore_password: String,
 }

--- a/cargo-apk/src/manifest.rs
+++ b/cargo-apk/src/manifest.rs
@@ -80,6 +80,6 @@ struct AndroidMetadata {
 
 #[derive(Clone, Debug, Default, Deserialize)]
 pub(crate) struct Signing {
-    pub(crate) path: PathBuf,
+    pub(crate) path: Option<PathBuf>,
     pub(crate) keystore_password: String,
 }

--- a/ndk-build/CHANGELOG.md
+++ b/ndk-build/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `ndk::DEFAULT_DEV_KEYSTORE_PASSWORD` and make `apk::ApkConfig::apk` public. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
+
 (0.8.1, released on 2022-10-14, was yanked due to violating semver.)
 
 - **Breaking:** Provide `reverse_port_forwarding()` to set up `adb reverse` ([#348](https://github.com/rust-windowing/android-ndk-rs/pull/348))

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -32,7 +32,7 @@ impl ApkConfig {
             .join(format!("{}-unaligned.apk", self.apk_name))
     }
 
-    fn apk(&self) -> PathBuf {
+    pub fn apk(&self) -> PathBuf {
         self.build_dir.join(format!("{}.apk", self.apk_name))
     }
 

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -32,6 +32,9 @@ impl ApkConfig {
             .join(format!("{}-unaligned.apk", self.apk_name))
     }
 
+    /// Retrieves the path of the APK that will be written when [`UnsignedApk::sign`]
+    /// is invoked
+    #[inline]
     pub fn apk(&self) -> PathBuf {
         self.build_dir.join(format!("{}.apk", self.apk_name))
     }

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-pub const DEFAULT_DEV_PASSWORD: &str = "android";
+/// The default password used when creating the default `debug.keystore` via
+/// [`Ndk::debug_key`]
+pub const DEFAULT_DEV_KEYSTORE_PASSWORD: &str = "android";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ndk {
@@ -386,7 +388,7 @@ impl Ndk {
 
     pub fn debug_key(&self) -> Result<Key, NdkError> {
         let path = self.android_user_home()?.join("debug.keystore");
-        let password = DEFAULT_DEV_PASSWORD.to_owned();
+        let password = DEFAULT_DEV_KEYSTORE_PASSWORD.to_owned();
 
         if !path.exists() {
             let mut keytool = self.keytool()?;

--- a/ndk-build/src/ndk.rs
+++ b/ndk-build/src/ndk.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+pub const DEFAULT_DEV_PASSWORD: &str = "android";
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ndk {
     sdk_path: PathBuf,
@@ -384,7 +386,8 @@ impl Ndk {
 
     pub fn debug_key(&self) -> Result<Key, NdkError> {
         let path = self.android_user_home()?.join("debug.keystore");
-        let password = "android".to_string();
+        let password = DEFAULT_DEV_PASSWORD.to_owned();
+
         if !path.exists() {
             let mut keytool = self.keytool()?;
             keytool


### PR DESCRIPTION
In the cargo-apk docs, it has

```ini
[package.metadata.android.signing.<profile>]
path = "$HOME/.android/debug.keystore"
keystore_password = "android"
```

But the `$HOME` is a lie, cargo-apk doesn't actually expand environment variables, this change just adds a _very_ simple and dumb expansion, only if an environment variable is present at the beginning, and it actually exists.