### PR TITLE
cargo-apk: Inherit package configuration (`version`) from workspace root

### DIFF
--- a/cargo-apk/CHANGELOG.md
+++ b/cargo-apk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Profile signing information can now be specified via the `CARGO_APK_<PROFILE>_KEYSTORE` and `CARGO_APK_<PROFILE>_KEYSTORE_PASSWORD` environment variables. The environment variables take precedence over signing information in the cargo manifest. Both environment variables are required except in the case of the `dev` profile, which will fall back to the default password if `CARGO_APK_DEV_KEYSTORE_PASSWORD` is not set. ([#358](https://github.com/rust-windowing/android-ndk-rs/pull/358))
 - Add `strip` option to `android` metadata, allowing a user to specify how they want debug symbols treated after cargo has finished building, but before the shared object is copied into the APK. ([#356](https://github.com/rust-windowing/android-ndk-rs/pull/356))
+- Support [`[workspace.package]` inheritance](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspacepackage-table) from a workspace root manifest for the `version` field under `[package]`. ([#360](https://github.com/rust-windowing/android-ndk-rs/pull/360))
 
 (0.9.5, released on 2022-10-14, was yanked due to unintentionally bumping MSRV through the `quick-xml` crate, and breaking `cargo apk --` parsing after switching to `clap`.)
 

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.60"
 
 [dependencies]
 anyhow = "1.0.57"
-cargo-subcommand = "0.9"
+cargo-subcommand = "0.10"
 clap = { version = "4", features = ["derive"] }
 dunce = "1"
 env_logger = "0.9"

--- a/cargo-apk/src/error.rs
+++ b/cargo-apk/src/error.rs
@@ -16,6 +16,12 @@ pub enum Error {
     Io(#[from] IoError),
     #[error("Configure a release keystore via `[package.metadata.android.signing.{0}]`")]
     MissingReleaseKey(String),
+    #[error("`workspace=false` is unsupported")]
+    InheritedFalse,
+    #[error("`workspace=true` requires a workspace")]
+    InheritanceMissingWorkspace,
+    #[error("Failed to inherit field: `workspace.{0}` was not defined in workspace root manifest")]
+    WorkspaceMissingInheritedField(&'static str),
 }
 
 impl Error {


### PR DESCRIPTION
Depends on https://github.com/dvc94ch/cargo-subcommand/pull/23, https://github.com/dvc94ch/cargo-subcommand/pull/24
Fixes #359

Starting with [Rust 1.64] common `[package]` parameters (and dependencies) can now be specified in the workspace root manifest by setting `<field>.workspace=true` in a `[package]` and specifying its value in the workspace root manifest under [`[workspace.package]`][1].

Since `cargo-apk` reads the `version` field from `[package]` it has to support this new format and pull the value from the root manifest instead, in order to support projects utilizing this new format.

This is currently implemented ad-hoc for the version field, but could be done in a cleaner way if/when more fields are needed.

[Rust 1.64]: https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds
[1]: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspacepackage-table
