### PR TITLE
Lock MSRV to 1.60 and validate in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,20 @@ jobs:
         # also compile cleanly under this target.
         args: --all --all-targets --all-features --target aarch64-linux-android -- -Dwarnings
 
+  check_msrv:
+    name: Check MSRV (1.60.0)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dtolnay/rust-toolchain@1.60.0
+        with:
+          target: aarch64-linux-android
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          # See comment above about using one of our supported targets.
+          args: --workspace --all-targets --all-features --target aarch64-linux-android
+
   build:
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rust on Android
 
-[![Rust](https://github.com/rust-windowing/android-ndk-rs/workflows/Rust/badge.svg)](https://github.com/rust-windowing/android-ndk-rs/actions) ![MIT license](https://img.shields.io/badge/License-MIT-green.svg) ![APACHE2 license](https://img.shields.io/badge/License-APACHE2-green.svg)
+[![Rust](https://github.com/rust-windowing/android-ndk-rs/workflows/Rust/badge.svg)](https://github.com/rust-windowing/android-ndk-rs/actions) ![MIT license](https://img.shields.io/badge/License-MIT-green.svg) ![APACHE2 license](https://img.shields.io/badge/License-APACHE2-green.svg) [![MSRV](https://img.shields.io/badge/rustc-1.60.0+-ab6000.svg)](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html)
+
 
 Libraries and tools for Rust programming on Android targets:
 

--- a/cargo-apk/Cargo.toml
+++ b/cargo-apk/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["android", "ndk", "apk"]
 documentation = "https://docs.rs/cargo-apk"
 homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
+rust-version = "1.60"
 
 [dependencies]
 anyhow = "1.0.57"

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.60"
 [dependencies]
 dirs = "4"
 dunce = "1"
-quick-xml = { version = "0.25", features = ["serialize"] }
+quick-xml = { version = "0.26", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 which = "4"

--- a/ndk-build/Cargo.toml
+++ b/ndk-build/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["android", "ndk", "apk"]
 documentation = "https://docs.rs/ndk-build"
 homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
+rust-version = "1.60"
 
 [dependencies]
 dirs = "4"

--- a/ndk-context/Cargo.toml
+++ b/ndk-context/Cargo.toml
@@ -9,3 +9,4 @@ keywords = ["android", "ndk", "apk", "jni"]
 documentation = "https://docs.rs/ndk-context"
 homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
+rust-version = "1.60"

--- a/ndk-glue/Cargo.toml
+++ b/ndk-glue/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 documentation = "https://docs.rs/ndk-glue"
 homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
+rust-version = "1.60"
 
 [dependencies]
 android_logger = { version = "0.11", optional = true }

--- a/ndk-macro/Cargo.toml
+++ b/ndk-macro/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 documentation = "https://docs.rs/ndk-macro"
 homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
+rust-version = "1.60"
 
 [lib]
 proc-macro = true

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 documentation = "https://docs.rs/android-ndk-sys"
 homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
+rust-version = "1.60"
 
 [dependencies]
 jni-sys = "0.3.0"

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 documentation = "https://docs.rs/android-ndk"
 homepage = "https://github.com/rust-windowing/android-ndk-rs"
 repository = "https://github.com/rust-windowing/android-ndk-rs"
+rust-version = "1.60"
 
 [features]
 all = ["audio", "bitmap","media", "api-level-30"]


### PR DESCRIPTION
CC @kchibisov

Prevent inadvertently bumping MSRV in PRs by checking against MSRV in the CI, to disallow any large bumps without rationale.  Rust 1.60 is 7 months old at the time of writing, and also required by `winit` which uses `android-ndk-rs`, hence must be compatible with it.

This does not mean that we cannot bump MSRV at all, but we must remain a tad conservative; at the same time setting [`rust-version`] in the manifest provides everyone on Rust 1.56 and higher a helpful error message when their version is lower than what we require.

[`rust-version`]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
