### PR TITLE
ndk-examples: Update `jni` dependency to `0.20`

### DIFF
--- a/ndk-examples/Cargo.toml
+++ b/ndk-examples/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [target.'cfg(target_os = "android")'.dependencies]
-jni = "0.19"
+jni = "0.20"
 libc = "0.2"
 log = "0.4.14"
 ndk = { path = "../ndk", features = ["api-level-23"] }


### PR DESCRIPTION
Fixes #364

Bump the `jni` dep for `ndk-examples` to 0.20.