### PR TITLE
Bump `jni-sys` to `0.4.0` and `jni` to `0.22`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ members = [
     "ndk",
     "ndk-sys",
 ]
+
+[patch.crates-io]
+jni = { git = "https://github.com/jni-rs/jni-rs" }

--- a/ndk-sys/CHANGELOG.md
+++ b/ndk-sys/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking:** Regenerate against NDK `25.2.9519653` with `rust-bindgen 0.66.0`. (#324, #370)
 - Add `font`, `font_matcher`, `system_fonts` bindings. (#397)
 - Add `sync` feature for linking against `libsync.so`. (#423)
+- **Breaking:** Bump `jni-sys` dependency to 0.4. (#433)
 
 # 0.4.1 (2022-11-23)
 

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/rust-mobile/ndk"
 rust-version = "1.60"
 
 [dependencies]
-jni-sys = "0.3.0"
+jni-sys = "0.4.0"
 
 [features]
 test = []

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Add bindings for `ASharedMemory`. (#427)
 - hardware_buffer: Add `id()` to retrieve a system-wide unique identifier for a `HardwareBuffer`. (#428)
 - **Breaking:** bitmap: Strip `Android` prefix from structs and enums, and `Bitmap` from `Result`. (#430)
+- **Breaking:** Bump `jni-sys` dependency to `0.4` and `jni` to `0.22`. (#433)
 - **Breaking:** `raw-window-handle 0.5` support is now behind an _optional_ `rwh_05` crate feature and `raw-window-handle` `0.4` and `0.6` support is provided via the new `rwh_04` and (default-enabled) `rwh_06` crate features. (#434)
 - **Breaking:** looper: Provide `event` value to file descriptor poll callback. (#435)
 - **Breaking:** `HardwareBufferFormat` is no longer exported from `hardware_buffer` and `native_window`, and can only be reached through the `hardware_buffer_format` module. (#436)

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -35,7 +35,7 @@ test = ["ffi/test", "jni", "all"]
 
 [dependencies]
 bitflags = "2.2"
-jni-sys = "0.3"
+jni-sys = "0.4"
 log = "0.4.6"
 num_enum = "0.7"
 rwh_04 = { package = "raw-window-handle", version = "0.4", optional = true }
@@ -44,6 +44,7 @@ rwh_06 = { package = "raw-window-handle", version = "0.6", optional = true }
 thiserror = "1.0.23"
 
 [dependencies.jni]
+# version = "0.22"
 version = "0.21"
 optional = true
 


### PR DESCRIPTION
https://github.com/jni-rs/jni-sys/releases/tag/v0.4.0
https://github.com/jni-rs/jni-rs/releases/tag/v0.22.0