### PR TITLE
Add bindings for Thermal Manager

### DIFF
--- a/ndk-sys/CHANGELOG.md
+++ b/ndk-sys/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Regenerate bindings with `bindgen 0.71.1`. (#487)
+- Regenerate with definitions from `thermal.h`. (#481)
 
 # 0.6.0 (2024-04-26)
 

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndk-sys"
-version = "0.6.0+11769913"
+version = "0.6.0+12180034"
 authors = ["The Rust Windowing contributors"]
 edition = "2021"
 description = "FFI bindings for the Android NDK"

--- a/ndk-sys/generate_bindings.sh
+++ b/ndk-sys/generate_bindings.sh
@@ -48,6 +48,7 @@ while read ARCH && read TARGET ; do
         --newtype-enum 'ANativeWindow_ChangeFrameRateStrategy' \
         --newtype-enum 'ANativeWindow_FrameRateCompatibility' \
         --newtype-enum 'ANativeWindow_LegacyFormat' \
+        --newtype-enum 'AThermalStatus' \
         --newtype-enum 'AndroidBitmapCompressFormat' \
         --newtype-enum 'AndroidBitmapFormat' \
         --newtype-enum 'AppendMode' \

--- a/ndk-sys/src/ffi_aarch64.rs
+++ b/ndk-sys/src/ffi_aarch64.rs
@@ -95,6 +95,7 @@ pub const SIG_ATOMIC_MIN: i32 = -2147483648;
 pub const WINT_MAX: u32 = 4294967295;
 pub const WINT_MIN: u32 = 0;
 pub const __BITS_PER_LONG: u32 = 64;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
@@ -824,6 +825,7 @@ pub const EXTRA_MAGIC: u32 = 1163416577;
 pub const SVE_MAGIC: u32 = 1398162689;
 pub const SVE_SIG_FLAG_SM: u32 = 1;
 pub const TPIDR2_MAGIC: u32 = 1414547714;
+pub const FPMR_MAGIC: u32 = 1179667794;
 pub const ZA_MAGIC: u32 = 1412850501;
 pub const ZT_MAGIC: u32 = 1515474433;
 pub const __SVE_VQ_BYTES: u32 = 16;
@@ -2635,88 +2637,88 @@ impl ADataSpace {
     pub const ADATASPACE_UNKNOWN: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const STANDARD_MASK: ADataSpace = ADataSpace(4128768);
+    pub const ADATASPACE_STANDARD_MASK: ADataSpace = ADataSpace(4128768);
 }
 impl ADataSpace {
-    pub const STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const STANDARD_BT709: ADataSpace = ADataSpace(65536);
+    pub const ADATASPACE_STANDARD_BT709: ADataSpace = ADataSpace(65536);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
+    pub const ADATASPACE_STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
+    pub const ADATASPACE_STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
+    pub const ADATASPACE_STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
+    pub const ADATASPACE_STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
 }
 impl ADataSpace {
-    pub const STANDARD_BT2020: ADataSpace = ADataSpace(393216);
+    pub const ADATASPACE_STANDARD_BT2020: ADataSpace = ADataSpace(393216);
 }
 impl ADataSpace {
-    pub const STANDARD_BT2020_CONSTANT_LUMINANCE: ADataSpace = ADataSpace(458752);
+    pub const ADATASPACE_STANDARD_BT2020_CONSTANT_LUMINANCE: ADataSpace = ADataSpace(458752);
 }
 impl ADataSpace {
-    pub const STANDARD_BT470M: ADataSpace = ADataSpace(524288);
+    pub const ADATASPACE_STANDARD_BT470M: ADataSpace = ADataSpace(524288);
 }
 impl ADataSpace {
-    pub const STANDARD_FILM: ADataSpace = ADataSpace(589824);
+    pub const ADATASPACE_STANDARD_FILM: ADataSpace = ADataSpace(589824);
 }
 impl ADataSpace {
-    pub const STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
+    pub const ADATASPACE_STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
 }
 impl ADataSpace {
-    pub const STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
+    pub const ADATASPACE_STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
 }
 impl ADataSpace {
-    pub const TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
+    pub const ADATASPACE_TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
 }
 impl ADataSpace {
-    pub const TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
+    pub const ADATASPACE_TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
 }
 impl ADataSpace {
-    pub const TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
+    pub const ADATASPACE_TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
 }
 impl ADataSpace {
-    pub const TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
+    pub const ADATASPACE_TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
+    pub const ADATASPACE_TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
+    pub const ADATASPACE_TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
+    pub const ADATASPACE_TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
 }
 impl ADataSpace {
-    pub const TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
+    pub const ADATASPACE_TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
 }
 impl ADataSpace {
-    pub const TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
+    pub const ADATASPACE_TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
 }
 impl ADataSpace {
-    pub const RANGE_MASK: ADataSpace = ADataSpace(939524096);
+    pub const ADATASPACE_RANGE_MASK: ADataSpace = ADataSpace(939524096);
 }
 impl ADataSpace {
-    pub const RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const RANGE_FULL: ADataSpace = ADataSpace(134217728);
+    pub const ADATASPACE_RANGE_FULL: ADataSpace = ADataSpace(134217728);
 }
 impl ADataSpace {
-    pub const RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
+    pub const ADATASPACE_RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
 }
 impl ADataSpace {
-    pub const RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
+    pub const ADATASPACE_RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
 }
 impl ADataSpace {
     pub const ADATASPACE_SCRGB_LINEAR: ADataSpace = ADataSpace(406913024);
@@ -2771,6 +2773,87 @@ impl ADataSpace {
 }
 impl ADataSpace {
     pub const ADATASPACE_DYNAMIC_DEPTH: ADataSpace = ADataSpace(4098);
+}
+impl ADataSpace {
+    pub const STANDARD_MASK: ADataSpace = ADataSpace(4128768);
+}
+impl ADataSpace {
+    pub const STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const STANDARD_BT709: ADataSpace = ADataSpace(65536);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
+}
+impl ADataSpace {
+    pub const STANDARD_BT470M: ADataSpace = ADataSpace(524288);
+}
+impl ADataSpace {
+    pub const STANDARD_BT2020: ADataSpace = ADataSpace(393216);
+}
+impl ADataSpace {
+    pub const STANDARD_FILM: ADataSpace = ADataSpace(589824);
+}
+impl ADataSpace {
+    pub const STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
+}
+impl ADataSpace {
+    pub const STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
+}
+impl ADataSpace {
+    pub const TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
+}
+impl ADataSpace {
+    pub const TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
+}
+impl ADataSpace {
+    pub const TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
+}
+impl ADataSpace {
+    pub const TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
+}
+impl ADataSpace {
+    pub const TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
+}
+impl ADataSpace {
+    pub const TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
+}
+impl ADataSpace {
+    pub const RANGE_MASK: ADataSpace = ADataSpace(939524096);
+}
+impl ADataSpace {
+    pub const RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const RANGE_FULL: ADataSpace = ADataSpace(134217728);
+}
+impl ADataSpace {
+    pub const RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
+}
+impl ADataSpace {
+    pub const RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
 }
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -4205,6 +4288,8 @@ pub const AKEYCODE_MACRO_1: _bindgen_ty_13 = 313;
 pub const AKEYCODE_MACRO_2: _bindgen_ty_13 = 314;
 pub const AKEYCODE_MACRO_3: _bindgen_ty_13 = 315;
 pub const AKEYCODE_MACRO_4: _bindgen_ty_13 = 316;
+pub const AKEYCODE_EMOJI_PICKER: _bindgen_ty_13 = 317;
+pub const AKEYCODE_SCREENSHOT: _bindgen_ty_13 = 318;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -4722,6 +4807,9 @@ extern "C" {
 }
 extern "C" {
     pub fn AMotionEvent_fromJava(env: *mut JNIEnv, motionEvent: jobject) -> *const AInputEvent;
+}
+extern "C" {
+    pub fn AInputEvent_toJava(env: *mut JNIEnv, aInputEvent: *const AInputEvent) -> jobject;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6809,8 +6897,8 @@ extern "C" {
 }
 extern "C" {
     pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
+        __array: *mut ::std::os::raw::c_void,
+        __n: usize,
         __size: usize,
         __comparator: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6818,6 +6906,21 @@ extern "C" {
                 __rhs: *const ::std::os::raw::c_void,
             ) -> ::std::os::raw::c_int,
         >,
+    );
+}
+extern "C" {
+    pub fn qsort_r(
+        __array: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __size: usize,
+        __comparator: ::std::option::Option<
+            unsafe extern "C" fn(
+                __lhs: *const ::std::os::raw::c_void,
+                __rhs: *const ::std::os::raw::c_void,
+                __context: *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+        __context: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
@@ -9288,6 +9391,47 @@ fn bindgen_test_layout_tpidr2_context() {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct fpmr_context {
+    pub head: _aarch64_ctx,
+    pub fpmr: __u64,
+}
+#[test]
+fn bindgen_test_layout_fpmr_context() {
+    const UNINIT: ::std::mem::MaybeUninit<fpmr_context> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<fpmr_context>(),
+        16usize,
+        concat!("Size of: ", stringify!(fpmr_context))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<fpmr_context>(),
+        8usize,
+        concat!("Alignment of ", stringify!(fpmr_context))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).head) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(fpmr_context),
+            "::",
+            stringify!(head)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).fpmr) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(fpmr_context),
+            "::",
+            stringify!(fpmr)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct za_context {
     pub head: _aarch64_ctx,
     pub vl: __u16,
@@ -11408,7 +11552,7 @@ extern "C" {
     pub fn AWorkDuration_create() -> *mut AWorkDuration;
 }
 extern "C" {
-    pub fn AWorkDuration_release(WorkDuration: *mut AWorkDuration);
+    pub fn AWorkDuration_release(aWorkDuration: *mut AWorkDuration);
 }
 extern "C" {
     pub fn AWorkDuration_setWorkPeriodStartTimestampNanos(
@@ -11965,12 +12109,6 @@ extern "C" {
 }
 extern "C" {
     pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
-}
-extern "C" {
-    pub fn isinf(__x: f64) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn isnan(__x: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
@@ -15186,7 +15324,10 @@ impl acamera_metadata_section {
     pub const ACAMERA_JPEGR: acamera_metadata_section = acamera_metadata_section(33);
 }
 impl acamera_metadata_section {
-    pub const ACAMERA_SECTION_COUNT: acamera_metadata_section = acamera_metadata_section(34);
+    pub const ACAMERA_EFV: acamera_metadata_section = acamera_metadata_section(34);
+}
+impl acamera_metadata_section {
+    pub const ACAMERA_SECTION_COUNT: acamera_metadata_section = acamera_metadata_section(35);
 }
 impl acamera_metadata_section {
     pub const ACAMERA_VENDOR: acamera_metadata_section = acamera_metadata_section(32768);
@@ -15330,6 +15471,10 @@ impl acamera_metadata_section_start {
 impl acamera_metadata_section_start {
     pub const ACAMERA_JPEGR_START: acamera_metadata_section_start =
         acamera_metadata_section_start(2162688);
+}
+impl acamera_metadata_section_start {
+    pub const ACAMERA_EFV_START: acamera_metadata_section_start =
+        acamera_metadata_section_start(2228224);
 }
 impl acamera_metadata_section_start {
     pub const ACAMERA_VENDOR_START: acamera_metadata_section_start =
@@ -18638,7 +18783,7 @@ pub struct ACaptureRequest {
 }
 extern "C" {
     pub fn ACameraOutputTarget_create(
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         output: *mut *mut ACameraOutputTarget,
     ) -> camera_status_t;
 }
@@ -18854,7 +18999,7 @@ fn bindgen_test_layout_ACameraCaptureSession_stateCallbacks() {
 pub type ACameraCaptureSession_prepareCallback = ::std::option::Option<
     unsafe extern "C" fn(
         context: *mut ::std::os::raw::c_void,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         session: *mut ACameraCaptureSession,
     ),
 >;
@@ -18949,7 +19094,7 @@ pub type ACameraCaptureSession_captureCallback_bufferLost = ::std::option::Optio
         context: *mut ::std::os::raw::c_void,
         session: *mut ACameraCaptureSession,
         request: *mut ACaptureRequest,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         frameNumber: i64,
     ),
 >;
@@ -19356,7 +19501,7 @@ extern "C" {
 extern "C" {
     pub fn ACameraCaptureSession_prepareWindow(
         session: *mut ACameraCaptureSession,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 #[repr(C)]
@@ -19497,7 +19642,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;
 }
@@ -19526,20 +19671,20 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_add(
         output: *mut ACaptureSessionOutput,
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_remove(
         output: *mut ACaptureSessionOutput,
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 extern "C" {
@@ -19553,7 +19698,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionPhysicalOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         physicalId: *const ::std::os::raw::c_char,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;

--- a/ndk-sys/src/ffi_aarch64.rs
+++ b/ndk-sys/src/ffi_aarch64.rs
@@ -14150,6 +14150,119 @@ extern "C" {
 extern "C" {
     pub fn ASystemFontIterator_next(iterator: *mut ASystemFontIterator) -> *mut AFont;
 }
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_ERROR: AThermalStatus = AThermalStatus(-1);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_NONE: AThermalStatus = AThermalStatus(0);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_LIGHT: AThermalStatus = AThermalStatus(1);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_MODERATE: AThermalStatus = AThermalStatus(2);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_SEVERE: AThermalStatus = AThermalStatus(3);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_CRITICAL: AThermalStatus = AThermalStatus(4);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_EMERGENCY: AThermalStatus = AThermalStatus(5);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_SHUTDOWN: AThermalStatus = AThermalStatus(6);
+}
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct AThermalStatus(pub ::std::os::raw::c_int);
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AThermalManager {
+    _unused: [u8; 0],
+}
+pub type AThermal_StatusCallback = ::std::option::Option<
+    unsafe extern "C" fn(data: *mut ::std::os::raw::c_void, status: AThermalStatus),
+>;
+extern "C" {
+    pub fn AThermal_acquireManager() -> *mut AThermalManager;
+}
+extern "C" {
+    pub fn AThermal_releaseManager(manager: *mut AThermalManager);
+}
+extern "C" {
+    pub fn AThermal_getCurrentThermalStatus(manager: *mut AThermalManager) -> AThermalStatus;
+}
+extern "C" {
+    pub fn AThermal_registerThermalStatusListener(
+        manager: *mut AThermalManager,
+        callback: AThermal_StatusCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn AThermal_unregisterThermalStatusListener(
+        manager: *mut AThermalManager,
+        callback: AThermal_StatusCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn AThermal_getThermalHeadroom(
+        manager: *mut AThermalManager,
+        forecastSeconds: ::std::os::raw::c_int,
+    ) -> f32;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AThermalHeadroomThreshold {
+    pub headroom: f32,
+    pub thermalStatus: AThermalStatus,
+}
+#[test]
+fn bindgen_test_layout_AThermalHeadroomThreshold() {
+    const UNINIT: ::std::mem::MaybeUninit<AThermalHeadroomThreshold> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<AThermalHeadroomThreshold>(),
+        8usize,
+        concat!("Size of: ", stringify!(AThermalHeadroomThreshold))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<AThermalHeadroomThreshold>(),
+        4usize,
+        concat!("Alignment of ", stringify!(AThermalHeadroomThreshold))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).headroom) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AThermalHeadroomThreshold),
+            "::",
+            stringify!(headroom)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).thermalStatus) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AThermalHeadroomThreshold),
+            "::",
+            stringify!(thermalStatus)
+        )
+    );
+}
+extern "C" {
+    pub fn AThermal_getThermalHeadroomThresholds(
+        manager: *mut AThermalManager,
+        outThresholds: *mut *const AThermalHeadroomThreshold,
+        size: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 extern "C" {
     pub fn ATrace_isEnabled() -> bool;
 }

--- a/ndk-sys/src/ffi_arm.rs
+++ b/ndk-sys/src/ffi_arm.rs
@@ -227,6 +227,7 @@ pub const UINTPTR_MAX: u32 = 4294967295;
 pub const PTRDIFF_MIN: i32 = -2147483648;
 pub const PTRDIFF_MAX: u32 = 2147483647;
 pub const SIZE_MAX: u32 = 4294967295;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
@@ -2678,88 +2679,88 @@ impl ADataSpace {
     pub const ADATASPACE_UNKNOWN: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const STANDARD_MASK: ADataSpace = ADataSpace(4128768);
+    pub const ADATASPACE_STANDARD_MASK: ADataSpace = ADataSpace(4128768);
 }
 impl ADataSpace {
-    pub const STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const STANDARD_BT709: ADataSpace = ADataSpace(65536);
+    pub const ADATASPACE_STANDARD_BT709: ADataSpace = ADataSpace(65536);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
+    pub const ADATASPACE_STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
+    pub const ADATASPACE_STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
+    pub const ADATASPACE_STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
+    pub const ADATASPACE_STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
 }
 impl ADataSpace {
-    pub const STANDARD_BT2020: ADataSpace = ADataSpace(393216);
+    pub const ADATASPACE_STANDARD_BT2020: ADataSpace = ADataSpace(393216);
 }
 impl ADataSpace {
-    pub const STANDARD_BT2020_CONSTANT_LUMINANCE: ADataSpace = ADataSpace(458752);
+    pub const ADATASPACE_STANDARD_BT2020_CONSTANT_LUMINANCE: ADataSpace = ADataSpace(458752);
 }
 impl ADataSpace {
-    pub const STANDARD_BT470M: ADataSpace = ADataSpace(524288);
+    pub const ADATASPACE_STANDARD_BT470M: ADataSpace = ADataSpace(524288);
 }
 impl ADataSpace {
-    pub const STANDARD_FILM: ADataSpace = ADataSpace(589824);
+    pub const ADATASPACE_STANDARD_FILM: ADataSpace = ADataSpace(589824);
 }
 impl ADataSpace {
-    pub const STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
+    pub const ADATASPACE_STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
 }
 impl ADataSpace {
-    pub const STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
+    pub const ADATASPACE_STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
 }
 impl ADataSpace {
-    pub const TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
+    pub const ADATASPACE_TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
 }
 impl ADataSpace {
-    pub const TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
+    pub const ADATASPACE_TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
 }
 impl ADataSpace {
-    pub const TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
+    pub const ADATASPACE_TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
 }
 impl ADataSpace {
-    pub const TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
+    pub const ADATASPACE_TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
+    pub const ADATASPACE_TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
+    pub const ADATASPACE_TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
+    pub const ADATASPACE_TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
 }
 impl ADataSpace {
-    pub const TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
+    pub const ADATASPACE_TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
 }
 impl ADataSpace {
-    pub const TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
+    pub const ADATASPACE_TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
 }
 impl ADataSpace {
-    pub const RANGE_MASK: ADataSpace = ADataSpace(939524096);
+    pub const ADATASPACE_RANGE_MASK: ADataSpace = ADataSpace(939524096);
 }
 impl ADataSpace {
-    pub const RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const RANGE_FULL: ADataSpace = ADataSpace(134217728);
+    pub const ADATASPACE_RANGE_FULL: ADataSpace = ADataSpace(134217728);
 }
 impl ADataSpace {
-    pub const RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
+    pub const ADATASPACE_RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
 }
 impl ADataSpace {
-    pub const RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
+    pub const ADATASPACE_RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
 }
 impl ADataSpace {
     pub const ADATASPACE_SCRGB_LINEAR: ADataSpace = ADataSpace(406913024);
@@ -2814,6 +2815,87 @@ impl ADataSpace {
 }
 impl ADataSpace {
     pub const ADATASPACE_DYNAMIC_DEPTH: ADataSpace = ADataSpace(4098);
+}
+impl ADataSpace {
+    pub const STANDARD_MASK: ADataSpace = ADataSpace(4128768);
+}
+impl ADataSpace {
+    pub const STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const STANDARD_BT709: ADataSpace = ADataSpace(65536);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
+}
+impl ADataSpace {
+    pub const STANDARD_BT470M: ADataSpace = ADataSpace(524288);
+}
+impl ADataSpace {
+    pub const STANDARD_BT2020: ADataSpace = ADataSpace(393216);
+}
+impl ADataSpace {
+    pub const STANDARD_FILM: ADataSpace = ADataSpace(589824);
+}
+impl ADataSpace {
+    pub const STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
+}
+impl ADataSpace {
+    pub const STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
+}
+impl ADataSpace {
+    pub const TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
+}
+impl ADataSpace {
+    pub const TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
+}
+impl ADataSpace {
+    pub const TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
+}
+impl ADataSpace {
+    pub const TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
+}
+impl ADataSpace {
+    pub const TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
+}
+impl ADataSpace {
+    pub const TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
+}
+impl ADataSpace {
+    pub const RANGE_MASK: ADataSpace = ADataSpace(939524096);
+}
+impl ADataSpace {
+    pub const RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const RANGE_FULL: ADataSpace = ADataSpace(134217728);
+}
+impl ADataSpace {
+    pub const RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
+}
+impl ADataSpace {
+    pub const RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
 }
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -3305,7 +3387,7 @@ impl AHardwareBuffer_UsageFlags {
 }
 impl AHardwareBuffer_UsageFlags {
     pub const AHARDWAREBUFFER_USAGE_FRONT_BUFFER: AHardwareBuffer_UsageFlags =
-        AHardwareBuffer_UsageFlags(2147483648);
+        AHardwareBuffer_UsageFlags(4294967296);
 }
 impl AHardwareBuffer_UsageFlags {
     pub const AHARDWAREBUFFER_USAGE_VENDOR_0: AHardwareBuffer_UsageFlags =
@@ -4248,6 +4330,8 @@ pub const AKEYCODE_MACRO_1: _bindgen_ty_13 = 313;
 pub const AKEYCODE_MACRO_2: _bindgen_ty_13 = 314;
 pub const AKEYCODE_MACRO_3: _bindgen_ty_13 = 315;
 pub const AKEYCODE_MACRO_4: _bindgen_ty_13 = 316;
+pub const AKEYCODE_EMOJI_PICKER: _bindgen_ty_13 = 317;
+pub const AKEYCODE_SCREENSHOT: _bindgen_ty_13 = 318;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -4765,6 +4849,9 @@ extern "C" {
 }
 extern "C" {
     pub fn AMotionEvent_fromJava(env: *mut JNIEnv, motionEvent: jobject) -> *const AInputEvent;
+}
+extern "C" {
+    pub fn AInputEvent_toJava(env: *mut JNIEnv, aInputEvent: *const AInputEvent) -> jobject;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6846,8 +6933,8 @@ extern "C" {
 }
 extern "C" {
     pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
+        __array: *mut ::std::os::raw::c_void,
+        __n: usize,
         __size: usize,
         __comparator: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6855,6 +6942,21 @@ extern "C" {
                 __rhs: *const ::std::os::raw::c_void,
             ) -> ::std::os::raw::c_int,
         >,
+    );
+}
+extern "C" {
+    pub fn qsort_r(
+        __array: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __size: usize,
+        __comparator: ::std::option::Option<
+            unsafe extern "C" fn(
+                __lhs: *const ::std::os::raw::c_void,
+                __rhs: *const ::std::os::raw::c_void,
+                __context: *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+        __context: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
@@ -11858,7 +11960,7 @@ extern "C" {
     pub fn AWorkDuration_create() -> *mut AWorkDuration;
 }
 extern "C" {
-    pub fn AWorkDuration_release(WorkDuration: *mut AWorkDuration);
+    pub fn AWorkDuration_release(aWorkDuration: *mut AWorkDuration);
 }
 extern "C" {
     pub fn AWorkDuration_setWorkPeriodStartTimestampNanos(
@@ -12415,12 +12517,6 @@ extern "C" {
 }
 extern "C" {
     pub fn fmal(__x: f64, __y: f64, __z: f64) -> f64;
-}
-extern "C" {
-    pub fn isinf(__x: f64) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn isnan(__x: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
@@ -15636,7 +15732,10 @@ impl acamera_metadata_section {
     pub const ACAMERA_JPEGR: acamera_metadata_section = acamera_metadata_section(33);
 }
 impl acamera_metadata_section {
-    pub const ACAMERA_SECTION_COUNT: acamera_metadata_section = acamera_metadata_section(34);
+    pub const ACAMERA_EFV: acamera_metadata_section = acamera_metadata_section(34);
+}
+impl acamera_metadata_section {
+    pub const ACAMERA_SECTION_COUNT: acamera_metadata_section = acamera_metadata_section(35);
 }
 impl acamera_metadata_section {
     pub const ACAMERA_VENDOR: acamera_metadata_section = acamera_metadata_section(32768);
@@ -15780,6 +15879,10 @@ impl acamera_metadata_section_start {
 impl acamera_metadata_section_start {
     pub const ACAMERA_JPEGR_START: acamera_metadata_section_start =
         acamera_metadata_section_start(2162688);
+}
+impl acamera_metadata_section_start {
+    pub const ACAMERA_EFV_START: acamera_metadata_section_start =
+        acamera_metadata_section_start(2228224);
 }
 impl acamera_metadata_section_start {
     pub const ACAMERA_VENDOR_START: acamera_metadata_section_start =
@@ -19088,7 +19191,7 @@ pub struct ACaptureRequest {
 }
 extern "C" {
     pub fn ACameraOutputTarget_create(
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         output: *mut *mut ACameraOutputTarget,
     ) -> camera_status_t;
 }
@@ -19304,7 +19407,7 @@ fn bindgen_test_layout_ACameraCaptureSession_stateCallbacks() {
 pub type ACameraCaptureSession_prepareCallback = ::std::option::Option<
     unsafe extern "C" fn(
         context: *mut ::std::os::raw::c_void,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         session: *mut ACameraCaptureSession,
     ),
 >;
@@ -19399,7 +19502,7 @@ pub type ACameraCaptureSession_captureCallback_bufferLost = ::std::option::Optio
         context: *mut ::std::os::raw::c_void,
         session: *mut ACameraCaptureSession,
         request: *mut ACaptureRequest,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         frameNumber: i64,
     ),
 >;
@@ -19806,7 +19909,7 @@ extern "C" {
 extern "C" {
     pub fn ACameraCaptureSession_prepareWindow(
         session: *mut ACameraCaptureSession,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 #[repr(C)]
@@ -19947,7 +20050,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;
 }
@@ -19976,20 +20079,20 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_add(
         output: *mut ACaptureSessionOutput,
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_remove(
         output: *mut ACaptureSessionOutput,
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 extern "C" {
@@ -20003,7 +20106,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionPhysicalOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         physicalId: *const ::std::os::raw::c_char,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;

--- a/ndk-sys/src/ffi_arm.rs
+++ b/ndk-sys/src/ffi_arm.rs
@@ -14558,6 +14558,119 @@ extern "C" {
 extern "C" {
     pub fn ASystemFontIterator_next(iterator: *mut ASystemFontIterator) -> *mut AFont;
 }
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_ERROR: AThermalStatus = AThermalStatus(-1);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_NONE: AThermalStatus = AThermalStatus(0);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_LIGHT: AThermalStatus = AThermalStatus(1);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_MODERATE: AThermalStatus = AThermalStatus(2);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_SEVERE: AThermalStatus = AThermalStatus(3);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_CRITICAL: AThermalStatus = AThermalStatus(4);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_EMERGENCY: AThermalStatus = AThermalStatus(5);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_SHUTDOWN: AThermalStatus = AThermalStatus(6);
+}
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct AThermalStatus(pub ::std::os::raw::c_int);
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AThermalManager {
+    _unused: [u8; 0],
+}
+pub type AThermal_StatusCallback = ::std::option::Option<
+    unsafe extern "C" fn(data: *mut ::std::os::raw::c_void, status: AThermalStatus),
+>;
+extern "C" {
+    pub fn AThermal_acquireManager() -> *mut AThermalManager;
+}
+extern "C" {
+    pub fn AThermal_releaseManager(manager: *mut AThermalManager);
+}
+extern "C" {
+    pub fn AThermal_getCurrentThermalStatus(manager: *mut AThermalManager) -> AThermalStatus;
+}
+extern "C" {
+    pub fn AThermal_registerThermalStatusListener(
+        manager: *mut AThermalManager,
+        callback: AThermal_StatusCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn AThermal_unregisterThermalStatusListener(
+        manager: *mut AThermalManager,
+        callback: AThermal_StatusCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn AThermal_getThermalHeadroom(
+        manager: *mut AThermalManager,
+        forecastSeconds: ::std::os::raw::c_int,
+    ) -> f32;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AThermalHeadroomThreshold {
+    pub headroom: f32,
+    pub thermalStatus: AThermalStatus,
+}
+#[test]
+fn bindgen_test_layout_AThermalHeadroomThreshold() {
+    const UNINIT: ::std::mem::MaybeUninit<AThermalHeadroomThreshold> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<AThermalHeadroomThreshold>(),
+        8usize,
+        concat!("Size of: ", stringify!(AThermalHeadroomThreshold))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<AThermalHeadroomThreshold>(),
+        4usize,
+        concat!("Alignment of ", stringify!(AThermalHeadroomThreshold))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).headroom) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AThermalHeadroomThreshold),
+            "::",
+            stringify!(headroom)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).thermalStatus) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AThermalHeadroomThreshold),
+            "::",
+            stringify!(thermalStatus)
+        )
+    );
+}
+extern "C" {
+    pub fn AThermal_getThermalHeadroomThresholds(
+        manager: *mut AThermalManager,
+        outThresholds: *mut *const AThermalHeadroomThreshold,
+        size: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 extern "C" {
     pub fn ATrace_isEnabled() -> bool;
 }

--- a/ndk-sys/src/ffi_i686.rs
+++ b/ndk-sys/src/ffi_i686.rs
@@ -90,6 +90,7 @@ pub const PTRDIFF_MIN: i32 = -2147483648;
 pub const PTRDIFF_MAX: u32 = 2147483647;
 pub const SIZE_MAX: u32 = 4294967295;
 pub const __BITS_PER_LONG: u32 = 32;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
@@ -2543,88 +2544,88 @@ impl ADataSpace {
     pub const ADATASPACE_UNKNOWN: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const STANDARD_MASK: ADataSpace = ADataSpace(4128768);
+    pub const ADATASPACE_STANDARD_MASK: ADataSpace = ADataSpace(4128768);
 }
 impl ADataSpace {
-    pub const STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const STANDARD_BT709: ADataSpace = ADataSpace(65536);
+    pub const ADATASPACE_STANDARD_BT709: ADataSpace = ADataSpace(65536);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
+    pub const ADATASPACE_STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
+    pub const ADATASPACE_STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
+    pub const ADATASPACE_STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
+    pub const ADATASPACE_STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
 }
 impl ADataSpace {
-    pub const STANDARD_BT2020: ADataSpace = ADataSpace(393216);
+    pub const ADATASPACE_STANDARD_BT2020: ADataSpace = ADataSpace(393216);
 }
 impl ADataSpace {
-    pub const STANDARD_BT2020_CONSTANT_LUMINANCE: ADataSpace = ADataSpace(458752);
+    pub const ADATASPACE_STANDARD_BT2020_CONSTANT_LUMINANCE: ADataSpace = ADataSpace(458752);
 }
 impl ADataSpace {
-    pub const STANDARD_BT470M: ADataSpace = ADataSpace(524288);
+    pub const ADATASPACE_STANDARD_BT470M: ADataSpace = ADataSpace(524288);
 }
 impl ADataSpace {
-    pub const STANDARD_FILM: ADataSpace = ADataSpace(589824);
+    pub const ADATASPACE_STANDARD_FILM: ADataSpace = ADataSpace(589824);
 }
 impl ADataSpace {
-    pub const STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
+    pub const ADATASPACE_STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
 }
 impl ADataSpace {
-    pub const STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
+    pub const ADATASPACE_STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
 }
 impl ADataSpace {
-    pub const TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
+    pub const ADATASPACE_TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
 }
 impl ADataSpace {
-    pub const TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
+    pub const ADATASPACE_TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
 }
 impl ADataSpace {
-    pub const TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
+    pub const ADATASPACE_TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
 }
 impl ADataSpace {
-    pub const TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
+    pub const ADATASPACE_TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
+    pub const ADATASPACE_TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
+    pub const ADATASPACE_TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
+    pub const ADATASPACE_TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
 }
 impl ADataSpace {
-    pub const TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
+    pub const ADATASPACE_TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
 }
 impl ADataSpace {
-    pub const TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
+    pub const ADATASPACE_TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
 }
 impl ADataSpace {
-    pub const RANGE_MASK: ADataSpace = ADataSpace(939524096);
+    pub const ADATASPACE_RANGE_MASK: ADataSpace = ADataSpace(939524096);
 }
 impl ADataSpace {
-    pub const RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const RANGE_FULL: ADataSpace = ADataSpace(134217728);
+    pub const ADATASPACE_RANGE_FULL: ADataSpace = ADataSpace(134217728);
 }
 impl ADataSpace {
-    pub const RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
+    pub const ADATASPACE_RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
 }
 impl ADataSpace {
-    pub const RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
+    pub const ADATASPACE_RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
 }
 impl ADataSpace {
     pub const ADATASPACE_SCRGB_LINEAR: ADataSpace = ADataSpace(406913024);
@@ -2679,6 +2680,87 @@ impl ADataSpace {
 }
 impl ADataSpace {
     pub const ADATASPACE_DYNAMIC_DEPTH: ADataSpace = ADataSpace(4098);
+}
+impl ADataSpace {
+    pub const STANDARD_MASK: ADataSpace = ADataSpace(4128768);
+}
+impl ADataSpace {
+    pub const STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const STANDARD_BT709: ADataSpace = ADataSpace(65536);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
+}
+impl ADataSpace {
+    pub const STANDARD_BT470M: ADataSpace = ADataSpace(524288);
+}
+impl ADataSpace {
+    pub const STANDARD_BT2020: ADataSpace = ADataSpace(393216);
+}
+impl ADataSpace {
+    pub const STANDARD_FILM: ADataSpace = ADataSpace(589824);
+}
+impl ADataSpace {
+    pub const STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
+}
+impl ADataSpace {
+    pub const STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
+}
+impl ADataSpace {
+    pub const TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
+}
+impl ADataSpace {
+    pub const TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
+}
+impl ADataSpace {
+    pub const TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
+}
+impl ADataSpace {
+    pub const TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
+}
+impl ADataSpace {
+    pub const TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
+}
+impl ADataSpace {
+    pub const TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
+}
+impl ADataSpace {
+    pub const RANGE_MASK: ADataSpace = ADataSpace(939524096);
+}
+impl ADataSpace {
+    pub const RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const RANGE_FULL: ADataSpace = ADataSpace(134217728);
+}
+impl ADataSpace {
+    pub const RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
+}
+impl ADataSpace {
+    pub const RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
 }
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -3170,7 +3252,7 @@ impl AHardwareBuffer_UsageFlags {
 }
 impl AHardwareBuffer_UsageFlags {
     pub const AHARDWAREBUFFER_USAGE_FRONT_BUFFER: AHardwareBuffer_UsageFlags =
-        AHardwareBuffer_UsageFlags(2147483648);
+        AHardwareBuffer_UsageFlags(4294967296);
 }
 impl AHardwareBuffer_UsageFlags {
     pub const AHARDWAREBUFFER_USAGE_VENDOR_0: AHardwareBuffer_UsageFlags =
@@ -4113,6 +4195,8 @@ pub const AKEYCODE_MACRO_1: _bindgen_ty_13 = 313;
 pub const AKEYCODE_MACRO_2: _bindgen_ty_13 = 314;
 pub const AKEYCODE_MACRO_3: _bindgen_ty_13 = 315;
 pub const AKEYCODE_MACRO_4: _bindgen_ty_13 = 316;
+pub const AKEYCODE_EMOJI_PICKER: _bindgen_ty_13 = 317;
+pub const AKEYCODE_SCREENSHOT: _bindgen_ty_13 = 318;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -4630,6 +4714,9 @@ extern "C" {
 }
 extern "C" {
     pub fn AMotionEvent_fromJava(env: *mut JNIEnv, motionEvent: jobject) -> *const AInputEvent;
+}
+extern "C" {
+    pub fn AInputEvent_toJava(env: *mut JNIEnv, aInputEvent: *const AInputEvent) -> jobject;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6717,8 +6804,8 @@ extern "C" {
 }
 extern "C" {
     pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
+        __array: *mut ::std::os::raw::c_void,
+        __n: usize,
         __size: usize,
         __comparator: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6726,6 +6813,21 @@ extern "C" {
                 __rhs: *const ::std::os::raw::c_void,
             ) -> ::std::os::raw::c_int,
         >,
+    );
+}
+extern "C" {
+    pub fn qsort_r(
+        __array: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __size: usize,
+        __comparator: ::std::option::Option<
+            unsafe extern "C" fn(
+                __lhs: *const ::std::os::raw::c_void,
+                __rhs: *const ::std::os::raw::c_void,
+                __context: *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+        __context: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
@@ -12575,7 +12677,7 @@ extern "C" {
     pub fn AWorkDuration_create() -> *mut AWorkDuration;
 }
 extern "C" {
-    pub fn AWorkDuration_release(WorkDuration: *mut AWorkDuration);
+    pub fn AWorkDuration_release(aWorkDuration: *mut AWorkDuration);
 }
 extern "C" {
     pub fn AWorkDuration_setWorkPeriodStartTimestampNanos(
@@ -13132,12 +13234,6 @@ extern "C" {
 }
 extern "C" {
     pub fn fmal(__x: f64, __y: f64, __z: f64) -> f64;
-}
-extern "C" {
-    pub fn isinf(__x: f64) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn isnan(__x: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
@@ -16353,7 +16449,10 @@ impl acamera_metadata_section {
     pub const ACAMERA_JPEGR: acamera_metadata_section = acamera_metadata_section(33);
 }
 impl acamera_metadata_section {
-    pub const ACAMERA_SECTION_COUNT: acamera_metadata_section = acamera_metadata_section(34);
+    pub const ACAMERA_EFV: acamera_metadata_section = acamera_metadata_section(34);
+}
+impl acamera_metadata_section {
+    pub const ACAMERA_SECTION_COUNT: acamera_metadata_section = acamera_metadata_section(35);
 }
 impl acamera_metadata_section {
     pub const ACAMERA_VENDOR: acamera_metadata_section = acamera_metadata_section(32768);
@@ -16497,6 +16596,10 @@ impl acamera_metadata_section_start {
 impl acamera_metadata_section_start {
     pub const ACAMERA_JPEGR_START: acamera_metadata_section_start =
         acamera_metadata_section_start(2162688);
+}
+impl acamera_metadata_section_start {
+    pub const ACAMERA_EFV_START: acamera_metadata_section_start =
+        acamera_metadata_section_start(2228224);
 }
 impl acamera_metadata_section_start {
     pub const ACAMERA_VENDOR_START: acamera_metadata_section_start =
@@ -19805,7 +19908,7 @@ pub struct ACaptureRequest {
 }
 extern "C" {
     pub fn ACameraOutputTarget_create(
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         output: *mut *mut ACameraOutputTarget,
     ) -> camera_status_t;
 }
@@ -20021,7 +20124,7 @@ fn bindgen_test_layout_ACameraCaptureSession_stateCallbacks() {
 pub type ACameraCaptureSession_prepareCallback = ::std::option::Option<
     unsafe extern "C" fn(
         context: *mut ::std::os::raw::c_void,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         session: *mut ACameraCaptureSession,
     ),
 >;
@@ -20116,7 +20219,7 @@ pub type ACameraCaptureSession_captureCallback_bufferLost = ::std::option::Optio
         context: *mut ::std::os::raw::c_void,
         session: *mut ACameraCaptureSession,
         request: *mut ACaptureRequest,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         frameNumber: i64,
     ),
 >;
@@ -20523,7 +20626,7 @@ extern "C" {
 extern "C" {
     pub fn ACameraCaptureSession_prepareWindow(
         session: *mut ACameraCaptureSession,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 #[repr(C)]
@@ -20664,7 +20767,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;
 }
@@ -20693,20 +20796,20 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_add(
         output: *mut ACaptureSessionOutput,
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_remove(
         output: *mut ACaptureSessionOutput,
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 extern "C" {
@@ -20720,7 +20823,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionPhysicalOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         physicalId: *const ::std::os::raw::c_char,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;

--- a/ndk-sys/src/ffi_i686.rs
+++ b/ndk-sys/src/ffi_i686.rs
@@ -15275,6 +15275,119 @@ extern "C" {
 extern "C" {
     pub fn ASystemFontIterator_next(iterator: *mut ASystemFontIterator) -> *mut AFont;
 }
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_ERROR: AThermalStatus = AThermalStatus(-1);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_NONE: AThermalStatus = AThermalStatus(0);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_LIGHT: AThermalStatus = AThermalStatus(1);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_MODERATE: AThermalStatus = AThermalStatus(2);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_SEVERE: AThermalStatus = AThermalStatus(3);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_CRITICAL: AThermalStatus = AThermalStatus(4);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_EMERGENCY: AThermalStatus = AThermalStatus(5);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_SHUTDOWN: AThermalStatus = AThermalStatus(6);
+}
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct AThermalStatus(pub ::std::os::raw::c_int);
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AThermalManager {
+    _unused: [u8; 0],
+}
+pub type AThermal_StatusCallback = ::std::option::Option<
+    unsafe extern "C" fn(data: *mut ::std::os::raw::c_void, status: AThermalStatus),
+>;
+extern "C" {
+    pub fn AThermal_acquireManager() -> *mut AThermalManager;
+}
+extern "C" {
+    pub fn AThermal_releaseManager(manager: *mut AThermalManager);
+}
+extern "C" {
+    pub fn AThermal_getCurrentThermalStatus(manager: *mut AThermalManager) -> AThermalStatus;
+}
+extern "C" {
+    pub fn AThermal_registerThermalStatusListener(
+        manager: *mut AThermalManager,
+        callback: AThermal_StatusCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn AThermal_unregisterThermalStatusListener(
+        manager: *mut AThermalManager,
+        callback: AThermal_StatusCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn AThermal_getThermalHeadroom(
+        manager: *mut AThermalManager,
+        forecastSeconds: ::std::os::raw::c_int,
+    ) -> f32;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AThermalHeadroomThreshold {
+    pub headroom: f32,
+    pub thermalStatus: AThermalStatus,
+}
+#[test]
+fn bindgen_test_layout_AThermalHeadroomThreshold() {
+    const UNINIT: ::std::mem::MaybeUninit<AThermalHeadroomThreshold> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<AThermalHeadroomThreshold>(),
+        8usize,
+        concat!("Size of: ", stringify!(AThermalHeadroomThreshold))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<AThermalHeadroomThreshold>(),
+        4usize,
+        concat!("Alignment of ", stringify!(AThermalHeadroomThreshold))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).headroom) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AThermalHeadroomThreshold),
+            "::",
+            stringify!(headroom)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).thermalStatus) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AThermalHeadroomThreshold),
+            "::",
+            stringify!(thermalStatus)
+        )
+    );
+}
+extern "C" {
+    pub fn AThermal_getThermalHeadroomThresholds(
+        manager: *mut AThermalManager,
+        outThresholds: *mut *const AThermalHeadroomThreshold,
+        size: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 extern "C" {
     pub fn ATrace_isEnabled() -> bool;
 }

--- a/ndk-sys/src/ffi_x86_64.rs
+++ b/ndk-sys/src/ffi_x86_64.rs
@@ -84,6 +84,7 @@ pub const SIG_ATOMIC_MIN: i32 = -2147483648;
 pub const WINT_MAX: u32 = 4294967295;
 pub const WINT_MIN: u32 = 0;
 pub const __BITS_PER_LONG: u32 = 64;
+pub const __BITS_PER_LONG_LONG: u32 = 64;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
@@ -2597,88 +2598,88 @@ impl ADataSpace {
     pub const ADATASPACE_UNKNOWN: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const STANDARD_MASK: ADataSpace = ADataSpace(4128768);
+    pub const ADATASPACE_STANDARD_MASK: ADataSpace = ADataSpace(4128768);
 }
 impl ADataSpace {
-    pub const STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const STANDARD_BT709: ADataSpace = ADataSpace(65536);
+    pub const ADATASPACE_STANDARD_BT709: ADataSpace = ADataSpace(65536);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
+    pub const ADATASPACE_STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
+    pub const ADATASPACE_STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
+    pub const ADATASPACE_STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
 }
 impl ADataSpace {
-    pub const STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
+    pub const ADATASPACE_STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
 }
 impl ADataSpace {
-    pub const STANDARD_BT2020: ADataSpace = ADataSpace(393216);
+    pub const ADATASPACE_STANDARD_BT2020: ADataSpace = ADataSpace(393216);
 }
 impl ADataSpace {
-    pub const STANDARD_BT2020_CONSTANT_LUMINANCE: ADataSpace = ADataSpace(458752);
+    pub const ADATASPACE_STANDARD_BT2020_CONSTANT_LUMINANCE: ADataSpace = ADataSpace(458752);
 }
 impl ADataSpace {
-    pub const STANDARD_BT470M: ADataSpace = ADataSpace(524288);
+    pub const ADATASPACE_STANDARD_BT470M: ADataSpace = ADataSpace(524288);
 }
 impl ADataSpace {
-    pub const STANDARD_FILM: ADataSpace = ADataSpace(589824);
+    pub const ADATASPACE_STANDARD_FILM: ADataSpace = ADataSpace(589824);
 }
 impl ADataSpace {
-    pub const STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
+    pub const ADATASPACE_STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
 }
 impl ADataSpace {
-    pub const STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
+    pub const ADATASPACE_STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
 }
 impl ADataSpace {
-    pub const TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
+    pub const ADATASPACE_TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
 }
 impl ADataSpace {
-    pub const TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
+    pub const ADATASPACE_TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
 }
 impl ADataSpace {
-    pub const TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
+    pub const ADATASPACE_TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
 }
 impl ADataSpace {
-    pub const TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
+    pub const ADATASPACE_TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
+    pub const ADATASPACE_TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
+    pub const ADATASPACE_TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
 }
 impl ADataSpace {
-    pub const TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
+    pub const ADATASPACE_TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
 }
 impl ADataSpace {
-    pub const TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
+    pub const ADATASPACE_TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
 }
 impl ADataSpace {
-    pub const TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
+    pub const ADATASPACE_TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
 }
 impl ADataSpace {
-    pub const RANGE_MASK: ADataSpace = ADataSpace(939524096);
+    pub const ADATASPACE_RANGE_MASK: ADataSpace = ADataSpace(939524096);
 }
 impl ADataSpace {
-    pub const RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
+    pub const ADATASPACE_RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
 }
 impl ADataSpace {
-    pub const RANGE_FULL: ADataSpace = ADataSpace(134217728);
+    pub const ADATASPACE_RANGE_FULL: ADataSpace = ADataSpace(134217728);
 }
 impl ADataSpace {
-    pub const RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
+    pub const ADATASPACE_RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
 }
 impl ADataSpace {
-    pub const RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
+    pub const ADATASPACE_RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
 }
 impl ADataSpace {
     pub const ADATASPACE_SCRGB_LINEAR: ADataSpace = ADataSpace(406913024);
@@ -2733,6 +2734,87 @@ impl ADataSpace {
 }
 impl ADataSpace {
     pub const ADATASPACE_DYNAMIC_DEPTH: ADataSpace = ADataSpace(4098);
+}
+impl ADataSpace {
+    pub const STANDARD_MASK: ADataSpace = ADataSpace(4128768);
+}
+impl ADataSpace {
+    pub const STANDARD_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const STANDARD_BT709: ADataSpace = ADataSpace(65536);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_625: ADataSpace = ADataSpace(131072);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_625_UNADJUSTED: ADataSpace = ADataSpace(196608);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_525: ADataSpace = ADataSpace(262144);
+}
+impl ADataSpace {
+    pub const STANDARD_BT601_525_UNADJUSTED: ADataSpace = ADataSpace(327680);
+}
+impl ADataSpace {
+    pub const STANDARD_BT470M: ADataSpace = ADataSpace(524288);
+}
+impl ADataSpace {
+    pub const STANDARD_BT2020: ADataSpace = ADataSpace(393216);
+}
+impl ADataSpace {
+    pub const STANDARD_FILM: ADataSpace = ADataSpace(589824);
+}
+impl ADataSpace {
+    pub const STANDARD_DCI_P3: ADataSpace = ADataSpace(655360);
+}
+impl ADataSpace {
+    pub const STANDARD_ADOBE_RGB: ADataSpace = ADataSpace(720896);
+}
+impl ADataSpace {
+    pub const TRANSFER_MASK: ADataSpace = ADataSpace(130023424);
+}
+impl ADataSpace {
+    pub const TRANSFER_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const TRANSFER_LINEAR: ADataSpace = ADataSpace(4194304);
+}
+impl ADataSpace {
+    pub const TRANSFER_SMPTE_170M: ADataSpace = ADataSpace(12582912);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_2: ADataSpace = ADataSpace(16777216);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_6: ADataSpace = ADataSpace(20971520);
+}
+impl ADataSpace {
+    pub const TRANSFER_GAMMA2_8: ADataSpace = ADataSpace(25165824);
+}
+impl ADataSpace {
+    pub const TRANSFER_SRGB: ADataSpace = ADataSpace(8388608);
+}
+impl ADataSpace {
+    pub const TRANSFER_ST2084: ADataSpace = ADataSpace(29360128);
+}
+impl ADataSpace {
+    pub const TRANSFER_HLG: ADataSpace = ADataSpace(33554432);
+}
+impl ADataSpace {
+    pub const RANGE_MASK: ADataSpace = ADataSpace(939524096);
+}
+impl ADataSpace {
+    pub const RANGE_UNSPECIFIED: ADataSpace = ADataSpace(0);
+}
+impl ADataSpace {
+    pub const RANGE_FULL: ADataSpace = ADataSpace(134217728);
+}
+impl ADataSpace {
+    pub const RANGE_LIMITED: ADataSpace = ADataSpace(268435456);
+}
+impl ADataSpace {
+    pub const RANGE_EXTENDED: ADataSpace = ADataSpace(402653184);
 }
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -4167,6 +4249,8 @@ pub const AKEYCODE_MACRO_1: _bindgen_ty_13 = 313;
 pub const AKEYCODE_MACRO_2: _bindgen_ty_13 = 314;
 pub const AKEYCODE_MACRO_3: _bindgen_ty_13 = 315;
 pub const AKEYCODE_MACRO_4: _bindgen_ty_13 = 316;
+pub const AKEYCODE_EMOJI_PICKER: _bindgen_ty_13 = 317;
+pub const AKEYCODE_SCREENSHOT: _bindgen_ty_13 = 318;
 pub type _bindgen_ty_13 = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -4684,6 +4768,9 @@ extern "C" {
 }
 extern "C" {
     pub fn AMotionEvent_fromJava(env: *mut JNIEnv, motionEvent: jobject) -> *const AInputEvent;
+}
+extern "C" {
+    pub fn AInputEvent_toJava(env: *mut JNIEnv, aInputEvent: *const AInputEvent) -> jobject;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6771,8 +6858,8 @@ extern "C" {
 }
 extern "C" {
     pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nmemb: usize,
+        __array: *mut ::std::os::raw::c_void,
+        __n: usize,
         __size: usize,
         __comparator: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6780,6 +6867,21 @@ extern "C" {
                 __rhs: *const ::std::os::raw::c_void,
             ) -> ::std::os::raw::c_int,
         >,
+    );
+}
+extern "C" {
+    pub fn qsort_r(
+        __array: *mut ::std::os::raw::c_void,
+        __n: usize,
+        __size: usize,
+        __comparator: ::std::option::Option<
+            unsafe extern "C" fn(
+                __lhs: *const ::std::os::raw::c_void,
+                __rhs: *const ::std::os::raw::c_void,
+                __context: *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+        __context: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
@@ -12613,7 +12715,7 @@ extern "C" {
     pub fn AWorkDuration_create() -> *mut AWorkDuration;
 }
 extern "C" {
-    pub fn AWorkDuration_release(WorkDuration: *mut AWorkDuration);
+    pub fn AWorkDuration_release(aWorkDuration: *mut AWorkDuration);
 }
 extern "C" {
     pub fn AWorkDuration_setWorkPeriodStartTimestampNanos(
@@ -13170,12 +13272,6 @@ extern "C" {
 }
 extern "C" {
     pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
-}
-extern "C" {
-    pub fn isinf(__x: f64) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn isnan(__x: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
@@ -16391,7 +16487,10 @@ impl acamera_metadata_section {
     pub const ACAMERA_JPEGR: acamera_metadata_section = acamera_metadata_section(33);
 }
 impl acamera_metadata_section {
-    pub const ACAMERA_SECTION_COUNT: acamera_metadata_section = acamera_metadata_section(34);
+    pub const ACAMERA_EFV: acamera_metadata_section = acamera_metadata_section(34);
+}
+impl acamera_metadata_section {
+    pub const ACAMERA_SECTION_COUNT: acamera_metadata_section = acamera_metadata_section(35);
 }
 impl acamera_metadata_section {
     pub const ACAMERA_VENDOR: acamera_metadata_section = acamera_metadata_section(32768);
@@ -16535,6 +16634,10 @@ impl acamera_metadata_section_start {
 impl acamera_metadata_section_start {
     pub const ACAMERA_JPEGR_START: acamera_metadata_section_start =
         acamera_metadata_section_start(2162688);
+}
+impl acamera_metadata_section_start {
+    pub const ACAMERA_EFV_START: acamera_metadata_section_start =
+        acamera_metadata_section_start(2228224);
 }
 impl acamera_metadata_section_start {
     pub const ACAMERA_VENDOR_START: acamera_metadata_section_start =
@@ -19843,7 +19946,7 @@ pub struct ACaptureRequest {
 }
 extern "C" {
     pub fn ACameraOutputTarget_create(
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         output: *mut *mut ACameraOutputTarget,
     ) -> camera_status_t;
 }
@@ -20059,7 +20162,7 @@ fn bindgen_test_layout_ACameraCaptureSession_stateCallbacks() {
 pub type ACameraCaptureSession_prepareCallback = ::std::option::Option<
     unsafe extern "C" fn(
         context: *mut ::std::os::raw::c_void,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         session: *mut ACameraCaptureSession,
     ),
 >;
@@ -20154,7 +20257,7 @@ pub type ACameraCaptureSession_captureCallback_bufferLost = ::std::option::Optio
         context: *mut ::std::os::raw::c_void,
         session: *mut ACameraCaptureSession,
         request: *mut ACaptureRequest,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
         frameNumber: i64,
     ),
 >;
@@ -20561,7 +20664,7 @@ extern "C" {
 extern "C" {
     pub fn ACameraCaptureSession_prepareWindow(
         session: *mut ACameraCaptureSession,
-        window: *mut ACameraWindowType,
+        window: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 #[repr(C)]
@@ -20702,7 +20805,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;
 }
@@ -20731,20 +20834,20 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_add(
         output: *mut ACaptureSessionOutput,
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 extern "C" {
     pub fn ACaptureSessionSharedOutput_remove(
         output: *mut ACaptureSessionOutput,
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
     ) -> camera_status_t;
 }
 extern "C" {
@@ -20758,7 +20861,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ACaptureSessionPhysicalOutput_create(
-        anw: *mut ACameraWindowType,
+        anw: *mut ANativeWindow,
         physicalId: *const ::std::os::raw::c_char,
         output: *mut *mut ACaptureSessionOutput,
     ) -> camera_status_t;

--- a/ndk-sys/src/ffi_x86_64.rs
+++ b/ndk-sys/src/ffi_x86_64.rs
@@ -15313,6 +15313,119 @@ extern "C" {
 extern "C" {
     pub fn ASystemFontIterator_next(iterator: *mut ASystemFontIterator) -> *mut AFont;
 }
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_ERROR: AThermalStatus = AThermalStatus(-1);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_NONE: AThermalStatus = AThermalStatus(0);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_LIGHT: AThermalStatus = AThermalStatus(1);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_MODERATE: AThermalStatus = AThermalStatus(2);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_SEVERE: AThermalStatus = AThermalStatus(3);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_CRITICAL: AThermalStatus = AThermalStatus(4);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_EMERGENCY: AThermalStatus = AThermalStatus(5);
+}
+impl AThermalStatus {
+    pub const ATHERMAL_STATUS_SHUTDOWN: AThermalStatus = AThermalStatus(6);
+}
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct AThermalStatus(pub ::std::os::raw::c_int);
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AThermalManager {
+    _unused: [u8; 0],
+}
+pub type AThermal_StatusCallback = ::std::option::Option<
+    unsafe extern "C" fn(data: *mut ::std::os::raw::c_void, status: AThermalStatus),
+>;
+extern "C" {
+    pub fn AThermal_acquireManager() -> *mut AThermalManager;
+}
+extern "C" {
+    pub fn AThermal_releaseManager(manager: *mut AThermalManager);
+}
+extern "C" {
+    pub fn AThermal_getCurrentThermalStatus(manager: *mut AThermalManager) -> AThermalStatus;
+}
+extern "C" {
+    pub fn AThermal_registerThermalStatusListener(
+        manager: *mut AThermalManager,
+        callback: AThermal_StatusCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn AThermal_unregisterThermalStatusListener(
+        manager: *mut AThermalManager,
+        callback: AThermal_StatusCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn AThermal_getThermalHeadroom(
+        manager: *mut AThermalManager,
+        forecastSeconds: ::std::os::raw::c_int,
+    ) -> f32;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AThermalHeadroomThreshold {
+    pub headroom: f32,
+    pub thermalStatus: AThermalStatus,
+}
+#[test]
+fn bindgen_test_layout_AThermalHeadroomThreshold() {
+    const UNINIT: ::std::mem::MaybeUninit<AThermalHeadroomThreshold> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<AThermalHeadroomThreshold>(),
+        8usize,
+        concat!("Size of: ", stringify!(AThermalHeadroomThreshold))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<AThermalHeadroomThreshold>(),
+        4usize,
+        concat!("Alignment of ", stringify!(AThermalHeadroomThreshold))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).headroom) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AThermalHeadroomThreshold),
+            "::",
+            stringify!(headroom)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).thermalStatus) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AThermalHeadroomThreshold),
+            "::",
+            stringify!(thermalStatus)
+        )
+    );
+}
+extern "C" {
+    pub fn AThermal_getThermalHeadroomThresholds(
+        manager: *mut AThermalManager,
+        outThresholds: *mut *const AThermalHeadroomThreshold,
+        size: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
 extern "C" {
     pub fn ATrace_isEnabled() -> bool;
 }

--- a/ndk-sys/wrapper.h
+++ b/ndk-sys/wrapper.h
@@ -61,7 +61,7 @@
 #include <android/surface_texture_jni.h>
 #include <android/sync.h>
 #include <android/system_fonts.h>
-// #include <android/thermal.h>
+#include <android/thermal.h>
 #include <android/trace.h>
 #include <android/versioning.h>
 #include <android/window.h>

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - image_reader: Add `ImageReader::new_with_data_space()` constructor and `ImageReader::data_space()` getter from API level 34. (#474)
 - Add bindings for Performance Hint manager (`APerformanceHintManager`, `APerformanceHintSession`, `AWorkDuration`). (#480)
+- Add bindings for Thermal (`AThermalManager`). (#481)
 
 # 0.9.0 (2024-04-26)
 

--- a/ndk/src/data_space.rs
+++ b/ndk/src/data_space.rs
@@ -425,7 +425,7 @@ pub enum DataSpaceStandard {
     /// Use the unadjusted `KR = 0.2627`, `KB = 0.0593` luminance interpretation for `RGB`
     /// conversion using the linear domain.
     #[doc(alias = "STANDARD_BT2020_CONSTANT_LUMINANCE")]
-    Bt2020ConstantLuminance = ffi::ADataSpace::STANDARD_BT2020_CONSTANT_LUMINANCE.0,
+    Bt2020ConstantLuminance = ffi::ADataSpace::ADATASPACE_STANDARD_BT2020_CONSTANT_LUMINANCE.0,
     /// | Primaries | x     | y    |
     /// | --------- | ----- | ---- |
     /// | green     | 0.21  |0.71  |

--- a/ndk/src/event.rs
+++ b/ndk/src/event.rs
@@ -176,6 +176,16 @@ impl InputEvent {
         }
     }
 
+    /// Creates a Java [`android.view.InputEvent`] object that is a copy of this native
+    /// [`InputEvent`].
+    ///
+    /// [`android.view.KeyEvent`]: https://developer.android.com/reference/android/view/KeyEvent
+    #[cfg(feature = "api-level-35")]
+    #[doc(alias = "AInputEvent_toJava")]
+    pub unsafe fn to_java(&self, env: *mut JNIEnv) -> jobject {
+        ffi::AInputEvent_toJava(env, self.ptr().as_ptr())
+    }
+
     /// Get the source of the event.
     ///
     /// See [the NDK
@@ -1992,6 +2002,11 @@ pub enum Keycode {
     ThumbsDown = ffi::AKEYCODE_THUMBS_DOWN as i32,
     #[doc(alias = "AKEYCODE_PROFILE_SWITCH")]
     ProfileSwitch = ffi::AKEYCODE_PROFILE_SWITCH as i32,
+    // TODO: Still missing a bunch here
+    /// Open Emoji picker
+    EmojiPicker = ffi::AKEYCODE_EMOJI_PICKER as i32,
+    /// Take Screenshot
+    Screenshot = ffi::AKEYCODE_SCREENSHOT as i32,
 
     #[doc(hidden)]
     #[num_enum(catch_all)]

--- a/ndk/src/lib.rs
+++ b/ndk/src/lib.rs
@@ -30,5 +30,6 @@ pub mod performance_hint;
 pub mod shared_memory;
 pub mod surface_texture;
 pub mod sync;
+pub mod thermal;
 pub mod trace;
 mod utils;

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -315,7 +315,10 @@ impl MediaCodec {
         }
     }
 
-    pub fn dequeue_input_buffer(&self, timeout: Duration) -> Result<DequeuedInputBufferResult<'_>> {
+    pub fn dequeue_input_buffer(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<DequeuedInputBufferResult<'_>> {
         let result = unsafe {
             ffi::AMediaCodec_dequeueInputBuffer(
                 self.as_ptr(),
@@ -377,7 +380,7 @@ impl MediaCodec {
         MediaError::from_status(status)
     }
 
-    pub fn input_buffer(&self, index: usize) -> Option<&mut [MaybeUninit<u8>]> {
+    pub fn input_buffer(&mut self, index: usize) -> Option<&mut [MaybeUninit<u8>]> {
         unsafe {
             let mut out_size = 0;
             let buffer_ptr = ffi::AMediaCodec_getInputBuffer(self.as_ptr(), index, &mut out_size);
@@ -533,7 +536,7 @@ impl Drop for MediaCodec {
 
 #[derive(Debug)]
 pub struct InputBuffer<'a> {
-    codec: &'a MediaCodec,
+    codec: &'a mut MediaCodec,
     index: usize,
 }
 

--- a/ndk/src/thermal.rs
+++ b/ndk/src/thermal.rs
@@ -1,0 +1,331 @@
+//! Bindings for [`AThermalManager`]
+//!
+//! Structures and functions to access thermal status and register/unregister thermal status
+//! listener in native code.
+//!
+//! [`AThermalManager`]: https://developer.android.com/ndk/reference/group/thermal#athermalmanager
+#![cfg(feature = "api-level-30")]
+
+#[cfg(doc)]
+use std::io::ErrorKind;
+use std::{io::Result, os::raw::c_void, ptr::NonNull};
+
+use num_enum::{FromPrimitive, IntoPrimitive};
+
+use crate::utils::abort_on_panic;
+
+/// Workaround for <https://issuetracker.google.com/issues/358664965>.  `status_t` should only
+/// contain negative error codes, but the underlying `AThermal` implementation freely passes
+/// positive error codes around. At least the expected return codes are "implicitly" documented to
+/// be positive.
+fn status_to_io_result(status: i32) -> Result<()> {
+    // Intentionally not imported in scope (and an identically-named function) to prevent
+    // accidentally calling this function without negation.
+    crate::utils::status_to_io_result(-status)
+}
+
+/// Thermal status used in function [`ThermalManager::current_thermal_status()`] and
+/// [`ThermalStatusCallback`].
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, FromPrimitive, IntoPrimitive)]
+#[repr(i32)]
+#[doc(alias = "AThermalStatus")]
+#[non_exhaustive]
+pub enum ThermalStatus {
+    /// Error in thermal status.
+    // TODO: Move to a Result?
+    #[doc(alias = "ATHERMAL_STATUS_ERROR")]
+    Error = ffi::AThermalStatus::ATHERMAL_STATUS_ERROR.0,
+    /// Not under throttling.
+    #[doc(alias = "ATHERMAL_STATUS_NONE")]
+    None = ffi::AThermalStatus::ATHERMAL_STATUS_NONE.0,
+    /// Light throttling where UX is not impacted.
+    #[doc(alias = "ATHERMAL_STATUS_LIGHT")]
+    Light = ffi::AThermalStatus::ATHERMAL_STATUS_LIGHT.0,
+    /// Moderate throttling where UX is not largely impacted.
+    #[doc(alias = "ATHERMAL_STATUS_MODERATE")]
+    Moderate = ffi::AThermalStatus::ATHERMAL_STATUS_MODERATE.0,
+    /// Severe throttling where UX is largely impacted.
+    #[doc(alias = "ATHERMAL_STATUS_SEVERE")]
+    Severe = ffi::AThermalStatus::ATHERMAL_STATUS_SEVERE.0,
+    /// Platform has done everything to reduce power.
+    #[doc(alias = "ATHERMAL_STATUS_CRITICAL")]
+    Critical = ffi::AThermalStatus::ATHERMAL_STATUS_CRITICAL.0,
+    /// Key components in platform are shutting down due to thermal condition. Device
+    /// functionalities will be limited.
+    #[doc(alias = "ATHERMAL_STATUS_EMERGENCY")]
+    Emergency = ffi::AThermalStatus::ATHERMAL_STATUS_EMERGENCY.0,
+    /// Need shutdown immediately.
+    #[doc(alias = "ATHERMAL_STATUS_SHUTDOWN")]
+    Shutdown = ffi::AThermalStatus::ATHERMAL_STATUS_SHUTDOWN.0,
+
+    #[doc(hidden)]
+    #[num_enum(catch_all)]
+    __Unknown(i32),
+}
+
+impl From<ffi::AThermalStatus> for ThermalStatus {
+    fn from(value: ffi::AThermalStatus) -> Self {
+        value.0.into()
+    }
+}
+
+/// Prototype of the function that is called when thermal status changes. It's passed the updated
+/// thermal status as parameter.
+///
+/// # Warning
+/// [`ThermalManager`] is synchronized internally, and its lock is held while this callback is
+/// called.  Interacting with [`ThermalManager`] inside this closure *will* result in a deadlock.
+#[doc(alias = "AThermal_StatusCallback")]
+pub type ThermalStatusCallback = Box<dyn FnMut(ThermalStatus) + Send>;
+
+/// Token returned by [`ThermalManager::register_thermal_status_listener()`] for a given
+/// [`ThermalStatusCallback`].
+///
+/// Pass this to [`ThermalManager::unregister_thermal_status_listener()`] when you no longer wish to
+/// receive the callback.
+#[derive(Debug, PartialEq, Eq, Hash)]
+#[must_use = "Without this token the callback can no longer be unregistered and will leak Boxes"]
+pub struct ThermalStatusListenerToken {
+    func: ffi::AThermal_StatusCallback,
+    data: *mut ThermalStatusCallback,
+}
+
+// SAFETY: (un)register_thermal_status_listener() is internally synchronized
+unsafe impl Send for ThermalStatusListenerToken {}
+unsafe impl Sync for ThermalStatusListenerToken {}
+
+/// An opaque type representing a handle to a thermal manager. An instance of thermal manager must
+/// be acquired prior to using thermal status APIs.  It will be freed automatically on [`drop()`]
+/// after use.
+///
+/// To use:
+/// - Create a new thermal manager instance by calling the [`ThermalManager::new()`] function.
+/// - Get current thermal status with [`ThermalManager::current_thermal_status()`].
+/// - Register a thermal status listener with [`ThermalManager::register_thermal_status_listener()`].
+/// - Unregister a thermal status listener with
+///   [`ThermalManager::unregister_thermal_status_listener()`].
+/// - Release the thermal manager instance with [`drop()`].
+#[derive(Debug, PartialEq, Eq, Hash)]
+#[doc(alias = "AThermalManager")]
+pub struct ThermalManager {
+    ptr: NonNull<ffi::AThermalManager>,
+}
+
+// SAFETY: All AThermalManager methods are internally synchronized
+unsafe impl Send for ThermalManager {}
+unsafe impl Sync for ThermalManager {}
+
+impl ThermalManager {
+    /// Acquire an instance of the thermal manager.
+    ///
+    /// Returns [`None`] on failure.
+    #[doc(alias = "AThermal_acquireManager")]
+    pub fn new() -> Option<Self> {
+        NonNull::new(unsafe { ffi::AThermal_acquireManager() }).map(|ptr| Self { ptr })
+    }
+
+    /// Gets the current thermal status.
+    ///
+    /// Returns current thermal status, [`ThermalStatus::Error`] on failure.
+    // TODO: Result?
+    #[doc(alias = "AThermal_getCurrentThermalStatus")]
+    pub fn current_thermal_status(&self) -> ThermalStatus {
+        unsafe { ffi::AThermal_getCurrentThermalStatus(self.ptr.as_ptr()) }.into()
+    }
+
+    /// Register the thermal status listener for thermal status change.
+    ///
+    /// Will leak [`Box`]es unless [`ThermalManager::unregister_thermal_status_listener()`] is
+    /// called.
+    // TODO: This API properly mutex-syncs the callbacks with the destructor!  Meaning we can track
+    // `Box`es in `self` and trivially `drop()` them _after_ calling `AThermal_releaseManager()`!
+    ///
+    /// # Returns
+    /// - [`ErrorKind::InvalidInput`] if the listener and data pointer were previously added and not removed.
+    /// - [`ErrorKind::PermissionDenied`] if the required permission is not held.
+    /// - [`ErrorKind::BrokenPipe`] if communication with the system service has failed.
+    #[doc(alias = "AThermal_registerThermalStatusListener")]
+    pub fn register_thermal_status_listener(
+        &self,
+        callback: ThermalStatusCallback,
+    ) -> Result<ThermalStatusListenerToken> {
+        let boxed = Box::new(callback);
+        // This box is only freed when unregister() is called
+        let data = Box::into_raw(boxed);
+
+        unsafe extern "C" fn thermal_status_callback(
+            data: *mut c_void,
+            status: ffi::AThermalStatus,
+        ) {
+            abort_on_panic(|| {
+                let func: *mut ThermalStatusCallback = data.cast();
+                (*func)(status.into())
+            })
+        }
+
+        status_to_io_result(unsafe {
+            ffi::AThermal_registerThermalStatusListener(
+                self.ptr.as_ptr(),
+                Some(thermal_status_callback),
+                data.cast(),
+            )
+        })
+        .map(|()| ThermalStatusListenerToken {
+            func: Some(thermal_status_callback),
+            data,
+        })
+    }
+
+    /// Unregister the thermal status listener previously resgistered.
+    ///
+    /// # Returns
+    /// - [`ErrorKind::InvalidInput`] if the listener and data pointer were not previously added.
+    /// - [`ErrorKind::PermissionDenied`] if the required permission is not held.
+    /// - [`ErrorKind::BrokenPipe`] if communication with the system service has failed.
+    #[doc(alias = "AThermal_unregisterThermalStatusListener")]
+    pub fn unregister_thermal_status_listener(
+        &self,
+        token: ThermalStatusListenerToken,
+    ) -> Result<()> {
+        status_to_io_result(unsafe {
+            ffi::AThermal_unregisterThermalStatusListener(
+                self.ptr.as_ptr(),
+                token.func,
+                token.data.cast(),
+            )
+        })?;
+        let _ = unsafe { Box::from_raw(token.data) };
+        Ok(())
+    }
+
+    /// Provides an estimate of how much thermal headroom the device currently has before hitting
+    /// severe throttling.
+    ///
+    /// Note that this only attempts to track the headroom of slow-moving sensors, such as the
+    /// skin temperature sensor.  This means that there is no benefit to calling this function more
+    /// frequently than about once per second, and attempted to call significantly more frequently
+    /// may result in the function returning [`f32::NAN`].
+    ///
+    /// In addition, in order to be able to provide an accurate forecast, the system does not
+    /// attempt to forecast until it has multiple temperature samples from which to extrapolate.
+    /// This should only take a few seconds from the time of the first call, but during this time,
+    /// no forecasting will occur, and the current headroom will be returned regardless of the value
+    /// of `forecast_seconds`.
+    ///
+    /// The value returned is a non-negative float that represents how much of the thermal envelope
+    /// is in use (or is forecasted to be in use).  A value of `1.0` indicates that the device is
+    /// (or will be) throttled at [`ThermalStatus::Severe`].  Such throttling can affect the CPU,
+    /// GPU, and other subsystems.  Values may exceed `1.0`, but there is no implied mapping to
+    /// specific thermal levels beyond that point.  This means that values greater than `1.0` may
+    /// correspond to [`ThermalStatus::Severe`], but may also represent heavier throttling.
+    ///
+    /// A value of `0.0` corresponds to a fixed distance from `1.0`, but does not correspond to any
+    /// particular thermal status or temperature.  Values on `(0.0, 1.0]` may be expected to scale
+    /// linearly with temperature, though temperature changes over time are typically not linear.
+    /// Negative values will be clamped to `0.0` before returning.
+    ///
+    /// `forecast_seconds` specifies how many seconds into the future to forecast. Given that device
+    /// conditions may change at any time, forecasts from further in the
+    /// future will likely be less accurate than forecasts in the near future.
+    ////
+    /// # Returns
+    /// A value greater than equal to `0.0`, where `1.0` indicates the SEVERE throttling threshold,
+    /// as described above. Returns [`f32::NAN`] if the device does not support this functionality
+    /// or if this function is called significantly faster than once per second.
+    #[cfg(feature = "api-level-31")]
+    #[doc(alias = "AThermal_getThermalHeadroom")]
+    pub fn thermal_headroom(
+        &self,
+        // TODO: Duration, even though it has a granularity of seconds?
+        forecast_seconds: i32,
+    ) -> f32 {
+        unsafe { ffi::AThermal_getThermalHeadroom(self.ptr.as_ptr(), forecast_seconds) }
+    }
+
+    /// Gets the thermal headroom thresholds for all available thermal status.
+    ///
+    /// A thermal status will only exist in output if the device manufacturer has the corresponding
+    /// threshold defined for at least one of its slow-moving skin temperature sensors.  If it's
+    /// set, one should also expect to get it from [`ThermalManager::current_thermal_status()`] or
+    /// [`ThermalStatusCallback`].
+    ///
+    /// The headroom threshold is used to interpret the possible thermal throttling status
+    /// based on the headroom prediction.  For example, if the headroom threshold for
+    /// [`ThermalStatus::Light`] is `0.7`, and a headroom prediction in `10s` returns `0.75` (or
+    /// [`ThermalManager::thermal_headroom(10)`] = `0.75`), one can expect that in `10` seconds the
+    /// system could be in lightly throttled state if the workload remains the same.  The app can
+    /// consider taking actions according to the nearest throttling status the difference between
+    /// the headroom and the threshold.
+    ///
+    /// For new devices it's guaranteed to have a single sensor, but for older devices with
+    /// multiple sensors reporting different threshold values, the minimum threshold is taken to
+    /// be conservative on predictions.  Thus, when reading real-time headroom, it's not guaranteed
+    /// that a real-time value of `0.75` (or [`ThermalManager::thermal_headroom(0)`] = `0.75`)
+    /// exceeding the threshold of `0.7` above will always come with lightly throttled state (or
+    /// [`ThermalManager::current_thermal_status()`] = [`ThermalStatus::Light`]) but it can be lower
+    /// (or [`ThermalManager::current_thermal_status()`] = [`ThermalStatus::None`]). While it's
+    /// always guaranteed that the device won't be throttled heavier than the unmet threshold's
+    /// state, so a real-time headroom of `0.75` will never come with [`ThermalStatus::Moderate`]
+    /// but always lower, and `0.65` will never come with [`ThermalStatus::Light`] but
+    /// [`ThermalStatus::None`].
+    ///
+    /// The returned list of thresholds is cached on first successful query and owned by the thermal
+    /// manager, which will not change between calls to this function. The caller should only need
+    /// to free the manager with [`drop()`].
+    ///
+    /// # Returns
+    /// - [`ErrorKind::InvalidInput`] if outThresholds or size_t is nullptr, or *outThresholds is not nullptr.
+    /// - [`ErrorKind::BrokenPipe`] if communication with the system service has failed.
+    /// - [`ErrorKind::Unsupported`] if the feature is disabled by the current system.
+    #[cfg(feature = "api-level-35")]
+    #[doc(alias = "AThermal_getThermalHeadroomThresholds")]
+    pub fn thermal_headroom_thresholds(
+        &self,
+    ) -> Result<Option<impl ExactSizeIterator<Item = ThermalHeadroomThreshold> + '_>> {
+        let mut out_thresholds = std::ptr::null();
+        let mut out_size = 0;
+        status_to_io_result(unsafe {
+            ffi::AThermal_getThermalHeadroomThresholds(
+                self.ptr.as_ptr(),
+                &mut out_thresholds,
+                &mut out_size,
+            )
+        })?;
+        if out_thresholds.is_null() {
+            return Ok(None);
+        }
+        Ok(Some(
+            unsafe { std::slice::from_raw_parts(out_thresholds, out_size) }
+                .iter()
+                .map(|t| ThermalHeadroomThreshold {
+                    headroom: t.headroom,
+                    thermal_status: t.thermalStatus.into(),
+                }),
+        ))
+    }
+}
+
+impl Drop for ThermalManager {
+    /// Release the thermal manager pointer acquired via [`ThermalManager::new()`].
+    #[doc(alias = "AThermal_releaseManager")]
+    fn drop(&mut self) {
+        unsafe { ffi::AThermal_releaseManager(self.ptr.as_ptr()) }
+    }
+}
+
+/// This struct defines an instance of headroom threshold value and its status.
+///
+/// The value should be monotonically non-decreasing as the thermal status increases.  For
+/// [`ThermalStatus::Severe`], its headroom threshold is guaranteed to be `1.0`.  For status below
+/// severe status, the value should be lower or equal to `1.0`, and for status above severe, the
+/// value should be larger or equal to `1.0`.
+///
+/// Also see [`ThermalManager::thermal_headroom()`] for explanation on headroom, and
+/// [`ThermalManager::thermal_headroom_thresholds()`] for how to use this.
+#[cfg(feature = "api-level-35")]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[doc(alias = "AThermalHeadroomThreshold")]
+pub struct ThermalHeadroomThreshold {
+    headroom: f32,
+    thermal_status: ThermalStatus,
+}


### PR DESCRIPTION
The header for this got [fixed just yesterday](https://android-review.googlesource.com/c/platform/frameworks/native/+/3205910) to contain valid C so that we can parse it (without making trivial custom changes...) so now seems to be about the right time to actually write out the bindings and at least have them open in a PR!

---

https://developer.android.com/ndk/reference/group/thermal

`AThermal` allows querying the current thermal (throttling) status, as well as forecasts of future thermal statuses to allow applications to respond and mitigate possible throttling in the (near) future.
