### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://github.com/rust-mobile/ndk"
 repository = "https://github.com/rust-mobile/ndk"
 rust-version = "1.60"
 categories = ["os", "os::android-apis", "external-ffi-bindings"]
+include = ["Cargo.toml", "CHANGELOG.md", "src/**/*.rs", "../README.md"]
 
 [dependencies]
 jni-sys = "0.3.0"


### PR DESCRIPTION
During a dependency review we noticed that the ndk-sys crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.