### PR TITLE
Fix some clippy lints

### DIFF
--- a/ndk/src/asset.rs
+++ b/ndk/src/asset.rs
@@ -7,7 +7,7 @@
 use std::{
     ffi::{CStr, CString},
     io,
-    os::fd::{FromRawFd, OwnedFd},
+    os::fd::{FromRawFd as _, OwnedFd},
     ptr::NonNull,
 };
 

--- a/ndk/src/audio.rs
+++ b/ndk/src/audio.rs
@@ -573,7 +573,7 @@ impl AudioStreamBuilder {
     #[doc(alias = "AAudioStreamBuilder_setAllowedCapturePolicy")]
     pub fn allowed_capture_policy(self, capture_policy: AudioAllowedCapturePolicy) -> Self {
         unsafe {
-            ffi::AAudioStreamBuilder_setAllowedCapturePolicy(self.as_ptr(), capture_policy.into())
+            ffi::AAudioStreamBuilder_setAllowedCapturePolicy(self.as_ptr(), capture_policy.into());
         };
         self
     }
@@ -692,7 +692,7 @@ impl AudioStreamBuilder {
                 self.as_ptr(),
                 Some(ffi_callback),
                 ptr as *mut c_void,
-            )
+            );
         };
 
         self.data_callback = Some(boxed);
@@ -763,7 +763,7 @@ impl AudioStreamBuilder {
                 let err = AudioError::from_result(error).unwrap_err();
                 (*callback)(&stream, err);
                 std::mem::forget(stream);
-            })
+            });
         }
 
         unsafe {
@@ -771,7 +771,7 @@ impl AudioStreamBuilder {
                 self.as_ptr(),
                 Some(ffi_callback),
                 ptr as *mut c_void,
-            )
+            );
         };
 
         self.error_callback = Some(boxed);

--- a/ndk/src/configuration.rs
+++ b/ndk/src/configuration.rs
@@ -109,6 +109,7 @@ impl Configuration {
     }
 
     /// Create a new `Configuration`, with none of the values set.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         unsafe {
             Self {

--- a/ndk/src/data_space.rs
+++ b/ndk/src/data_space.rs
@@ -475,7 +475,7 @@ pub enum DataSpaceStandard {
 /// Transfer aspect.
 ///
 /// Transfer characteristics are the opto-electronic transfer characteristic at the source as a
-///function of linear optical intensity (luminance).
+/// function of linear optical intensity (luminance).
 ///
 /// For digital signals, `E` corresponds to the recorded value. Normally, the transfer function is
 /// applied in `RGB` space to each of the `R`, `G` and `B` components independently. This may result

--- a/ndk/src/event.rs
+++ b/ndk/src/event.rs
@@ -163,8 +163,8 @@ impl InputEvent {
     #[doc(alias = "AInputEvent_getType")]
     pub unsafe fn from_ptr(ptr: NonNull<ffi::AInputEvent>) -> Self {
         match ffi::AInputEvent_getType(ptr.as_ptr()) as u32 {
-            ffi::AINPUT_EVENT_TYPE_KEY => InputEvent::KeyEvent(KeyEvent::from_ptr(ptr)),
-            ffi::AINPUT_EVENT_TYPE_MOTION => InputEvent::MotionEvent(MotionEvent::from_ptr(ptr)),
+            ffi::AINPUT_EVENT_TYPE_KEY => Self::KeyEvent(KeyEvent::from_ptr(ptr)),
+            ffi::AINPUT_EVENT_TYPE_MOTION => Self::MotionEvent(MotionEvent::from_ptr(ptr)),
             x => panic!("Bad event type received: {}", x),
         }
     }
@@ -173,8 +173,8 @@ impl InputEvent {
     #[inline]
     pub fn ptr(&self) -> NonNull<ffi::AInputEvent> {
         match self {
-            InputEvent::MotionEvent(MotionEvent { ptr }) => *ptr,
-            InputEvent::KeyEvent(KeyEvent { ptr }) => *ptr,
+            Self::MotionEvent(MotionEvent { ptr }) => *ptr,
+            Self::KeyEvent(KeyEvent { ptr }) => *ptr,
         }
     }
 

--- a/ndk/src/event.rs
+++ b/ndk/src/event.rs
@@ -15,6 +15,8 @@ use std::ptr::NonNull;
 #[cfg(feature = "api-level-31")]
 use jni_sys::{jobject, JNIEnv};
 use num_enum::{FromPrimitive, IntoPrimitive};
+#[cfg(feature = "api-level-31")]
+use std::ops::Deref;
 
 /// A native [`AInputEvent *`]
 ///
@@ -33,7 +35,7 @@ pub enum InputEvent {
 pub struct MotionEventJava(MotionEvent);
 
 #[cfg(feature = "api-level-31")]
-impl std::ops::Deref for MotionEventJava {
+impl Deref for MotionEventJava {
     type Target = MotionEvent;
 
     fn deref(&self) -> &Self::Target {
@@ -58,7 +60,7 @@ impl Drop for MotionEventJava {
 pub struct KeyEventJava(KeyEvent);
 
 #[cfg(feature = "api-level-31")]
-impl std::ops::Deref for KeyEventJava {
+impl Deref for KeyEventJava {
     type Target = KeyEvent;
 
     fn deref(&self) -> &Self::Target {

--- a/ndk/src/font.rs
+++ b/ndk/src/font.rs
@@ -9,7 +9,7 @@
 use std::convert::TryFrom;
 use std::ffi::{CStr, OsStr};
 use std::fmt::{self, Write as _};
-use std::os::unix::prelude::OsStrExt;
+use std::os::unix::prelude::OsStrExt as _;
 use std::path::Path;
 use std::ptr::NonNull;
 

--- a/ndk/src/font.rs
+++ b/ndk/src/font.rs
@@ -37,51 +37,51 @@ impl FontWeight {
     /// The minimum value for the font weight value. Unlike [`ffi::AFONT_WEIGHT_MIN`] being `0`,
     /// [`FontWeight::MIN`] is `1` to make the `MIN..MAX` range be inclusive, keeping consistency
     /// between [`FontWeight`] and other types like `std::num::NonZeroU*`.
-    pub const MIN: FontWeight = FontWeight(ffi::AFONT_WEIGHT_MIN as u16 + 1);
+    pub const MIN: Self = Self(ffi::AFONT_WEIGHT_MIN as u16 + 1);
 
     /// A font weight value for the thin weight.
-    pub const THIN: FontWeight = FontWeight(ffi::AFONT_WEIGHT_THIN as u16);
+    pub const THIN: Self = Self(ffi::AFONT_WEIGHT_THIN as u16);
 
     /// A font weight value for the extra-light weight.
-    pub const EXTRA_LIGHT: FontWeight = FontWeight(ffi::AFONT_WEIGHT_EXTRA_LIGHT as u16);
+    pub const EXTRA_LIGHT: Self = Self(ffi::AFONT_WEIGHT_EXTRA_LIGHT as u16);
 
     /// A font weight value for the light weight.
-    pub const LIGHT: FontWeight = FontWeight(ffi::AFONT_WEIGHT_LIGHT as u16);
+    pub const LIGHT: Self = Self(ffi::AFONT_WEIGHT_LIGHT as u16);
 
     /// A font weight value for the normal weight.
-    pub const NORMAL: FontWeight = FontWeight(ffi::AFONT_WEIGHT_NORMAL as u16);
+    pub const NORMAL: Self = Self(ffi::AFONT_WEIGHT_NORMAL as u16);
 
     /// A font weight value for the medium weight.
-    pub const MEDIUM: FontWeight = FontWeight(ffi::AFONT_WEIGHT_MEDIUM as u16);
+    pub const MEDIUM: Self = Self(ffi::AFONT_WEIGHT_MEDIUM as u16);
 
     /// A font weight value for the semi-bold weight.
-    pub const SEMI_BOLD: FontWeight = FontWeight(ffi::AFONT_WEIGHT_SEMI_BOLD as u16);
+    pub const SEMI_BOLD: Self = Self(ffi::AFONT_WEIGHT_SEMI_BOLD as u16);
 
     /// A font weight value for the bold weight.
-    pub const BOLD: FontWeight = FontWeight(ffi::AFONT_WEIGHT_BOLD as u16);
+    pub const BOLD: Self = Self(ffi::AFONT_WEIGHT_BOLD as u16);
 
     /// A font weight value for the extra-bold weight.
-    pub const EXTRA_BOLD: FontWeight = FontWeight(ffi::AFONT_WEIGHT_EXTRA_BOLD as u16);
+    pub const EXTRA_BOLD: Self = Self(ffi::AFONT_WEIGHT_EXTRA_BOLD as u16);
 
     /// A font weight value for the black weight.
-    pub const BLACK: FontWeight = FontWeight(ffi::AFONT_WEIGHT_BLACK as u16);
+    pub const BLACK: Self = Self(ffi::AFONT_WEIGHT_BLACK as u16);
 
     /// The maximum value for the font weight value.
-    pub const MAX: FontWeight = FontWeight(ffi::AFONT_WEIGHT_MAX as u16);
+    pub const MAX: Self = Self(ffi::AFONT_WEIGHT_MAX as u16);
 }
 
 impl fmt::Display for FontWeight {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
-            FontWeight::THIN => "Thin",
-            FontWeight::EXTRA_LIGHT => "Extra Light (Ultra Light)",
-            FontWeight::LIGHT => "Light",
-            FontWeight::NORMAL => "Normal (Regular)",
-            FontWeight::MEDIUM => "Medium",
-            FontWeight::SEMI_BOLD => "Semi Bold (Demi Bold)",
-            FontWeight::BOLD => "Bold",
-            FontWeight::EXTRA_BOLD => "Extra Bold (Ultra Bold)",
-            FontWeight::BLACK => "Black (Heavy)",
+            Self::THIN => "Thin",
+            Self::EXTRA_LIGHT => "Extra Light (Ultra Light)",
+            Self::LIGHT => "Light",
+            Self::NORMAL => "Normal (Regular)",
+            Self::MEDIUM => "Medium",
+            Self::SEMI_BOLD => "Semi Bold (Demi Bold)",
+            Self::BOLD => "Bold",
+            Self::EXTRA_BOLD => "Extra Bold (Ultra Bold)",
+            Self::BLACK => "Black (Heavy)",
             _ => return writeln!(f, "{}", self.0),
         })
     }
@@ -103,7 +103,7 @@ impl TryFrom<u16> for FontWeight {
     type Error = FontWeightValueError;
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
-        FontWeight::new(value)
+        Self::new(value)
     }
 }
 
@@ -435,7 +435,7 @@ impl FontMatcher {
     pub fn new() -> Self {
         let ptr = NonNull::new(unsafe { ffi::AFontMatcher_create() })
             .expect("AFontMatcher_create returned NULL");
-        unsafe { FontMatcher::from_ptr(ptr) }
+        unsafe { Self::from_ptr(ptr) }
     }
 
     /// Performs the matching from the generic font family for the text and select one font.
@@ -533,7 +533,7 @@ impl SystemFontIterator {
     /// Creates a system font iterator.
     pub fn new() -> Option<Self> {
         NonNull::new(unsafe { ffi::ASystemFontIterator_open() })
-            .map(|p| unsafe { SystemFontIterator::from_ptr(p) })
+            .map(|p| unsafe { Self::from_ptr(p) })
     }
 }
 

--- a/ndk/src/font.rs
+++ b/ndk/src/font.rs
@@ -431,6 +431,7 @@ impl FontMatcher {
 
     /// Creates a new [`FontMatcher`] object. [`FontMatcher`] selects the best font from the
     /// parameters set by the user.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let ptr = NonNull::new(unsafe { ffi::AFontMatcher_create() })
             .expect("AFontMatcher_create returned NULL");

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -9,7 +9,7 @@ use std::{
     mem::MaybeUninit,
     ops::Deref,
     os::{
-        fd::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd},
+        fd::{AsRawFd as _, BorrowedFd, FromRawFd as _, IntoRawFd, OwnedFd},
         raw::c_void,
     },
     ptr::NonNull,

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -184,13 +184,13 @@ bitflags::bitflags! {
 impl HardwareBufferUsage {
     /// Helper to read [`HardwareBufferUsage::CPU_READ_MASK`] values.
     #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_READ_MASK")]
-    pub fn cpu_read(self) -> HardwareBufferUsage {
+    pub fn cpu_read(self) -> Self {
         self.intersection(Self::CPU_READ_MASK)
     }
 
     /// Helper to read [`HardwareBufferUsage::CPU_WRITE_MASK`] values.
     #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_WRITE_MASK")]
-    pub fn cpu_write(self) -> HardwareBufferUsage {
+    pub fn cpu_write(self) -> Self {
         self.intersection(Self::CPU_WRITE_MASK)
     }
 }

--- a/ndk/src/input_queue.rs
+++ b/ndk/src/input_queue.rs
@@ -115,7 +115,7 @@ impl InputQueue {
     #[doc(alias = "AInputQueue_finishEvent")]
     pub fn finish_event(&self, event: InputEvent, handled: bool) {
         unsafe {
-            ffi::AInputQueue_finishEvent(self.ptr.as_ptr(), event.ptr().as_ptr(), handled as c_int)
+            ffi::AInputQueue_finishEvent(self.ptr.as_ptr(), event.ptr().as_ptr(), handled as c_int);
         }
     }
 
@@ -131,7 +131,7 @@ impl InputQueue {
                 id,
                 None,
                 ptr::null_mut(),
-            )
+            );
         }
     }
 

--- a/ndk/src/looper.rs
+++ b/ndk/src/looper.rs
@@ -11,7 +11,7 @@
 
 use std::mem::ManuallyDrop;
 use std::os::{
-    fd::{AsRawFd, BorrowedFd, RawFd},
+    fd::{AsRawFd as _, BorrowedFd, RawFd},
     raw::c_void,
 };
 use std::ptr;

--- a/ndk/src/media/image_reader.rs
+++ b/ndk/src/media/image_reader.rs
@@ -225,7 +225,7 @@ impl ImageReader {
                 let listener: *mut ImageListener = context.cast();
                 (*listener)(&reader);
                 std::mem::forget(reader);
-            })
+            });
         }
 
         let mut listener = ffi::AImageReader_ImageListener {
@@ -257,7 +257,7 @@ impl ImageReader {
                 let listener: *mut BufferRemovedListener = context.cast();
                 (*listener)(&reader, &buffer);
                 std::mem::forget(reader);
-            })
+            });
         }
 
         let mut listener = ffi::AImageReader_BufferRemovedListener {

--- a/ndk/src/media/image_reader.rs
+++ b/ndk/src/media/image_reader.rs
@@ -5,7 +5,7 @@
 #![cfg(feature = "api-level-24")]
 
 #[cfg(feature = "api-level-26")]
-use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
+use std::os::fd::{FromRawFd as _, IntoRawFd as _, OwnedFd};
 use std::{ffi::c_void, fmt, mem::MaybeUninit, ptr::NonNull};
 
 use num_enum::{FromPrimitive, IntoPrimitive};

--- a/ndk/src/media/image_reader.rs
+++ b/ndk/src/media/image_reader.rs
@@ -77,9 +77,9 @@ pub enum AcquireResult<T> {
 impl<T> AcquireResult<T> {
     fn map<U>(self, f: impl FnOnce(T) -> U) -> AcquireResult<U> {
         match self {
-            AcquireResult::Image(img) => AcquireResult::Image(f(img)),
-            AcquireResult::NoBufferAvailable => AcquireResult::NoBufferAvailable,
-            AcquireResult::MaxImagesAcquired => AcquireResult::MaxImagesAcquired,
+            Self::Image(img) => AcquireResult::Image(f(img)),
+            Self::NoBufferAvailable => AcquireResult::NoBufferAvailable,
+            Self::MaxImagesAcquired => AcquireResult::MaxImagesAcquired,
         }
     }
 }

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -315,7 +315,10 @@ impl MediaCodec {
         }
     }
 
-    pub fn dequeue_input_buffer(&self, timeout: Duration) -> Result<DequeuedInputBufferResult<'_>> {
+    pub fn dequeue_input_buffer(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<DequeuedInputBufferResult<'_>> {
         let result = unsafe {
             ffi::AMediaCodec_dequeueInputBuffer(
                 self.as_ptr(),
@@ -377,7 +380,7 @@ impl MediaCodec {
         MediaError::from_status(status)
     }
 
-    pub fn input_buffer(&self, index: usize) -> Option<&mut [MaybeUninit<u8>]> {
+    pub fn input_buffer(&mut self, index: usize) -> Option<&mut [MaybeUninit<u8>]> {
         unsafe {
             let mut out_size = 0;
             let buffer_ptr = ffi::AMediaCodec_getInputBuffer(self.as_ptr(), index, &mut out_size);
@@ -533,7 +536,7 @@ impl Drop for MediaCodec {
 
 #[derive(Debug)]
 pub struct InputBuffer<'a> {
-    codec: &'a MediaCodec,
+    codec: &'a mut MediaCodec,
     index: usize,
 }
 

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -170,7 +170,7 @@ impl MediaCodec {
                 if let Some(f) = callback.on_input_available.as_mut() {
                     f(index as usize);
                 }
-            })
+            });
         }
 
         unsafe extern "C" fn ffi_on_output_available(
@@ -187,7 +187,7 @@ impl MediaCodec {
                     };
                     f(index as usize, &buffer_info);
                 }
-            })
+            });
         }
 
         unsafe extern "C" fn ffi_on_format_changed(
@@ -205,7 +205,7 @@ impl MediaCodec {
                 if let Some(f) = callback.on_format_changed.as_mut() {
                     f(&format);
                 }
-            })
+            });
         }
 
         unsafe extern "C" fn ffi_on_error(
@@ -224,7 +224,7 @@ impl MediaCodec {
                         CStr::from_ptr(detail),
                     );
                 }
-            })
+            });
         }
 
         let (callback, ffi_callback, user_data) = if let Some(callback) = callback {

--- a/ndk/src/media/media_format.rs
+++ b/ndk/src/media/media_format.rs
@@ -166,7 +166,7 @@ impl MediaFormat {
                 name.as_ptr(),
                 value.as_ptr().cast(),
                 value.len(),
-            )
+            );
         }
     }
 
@@ -259,6 +259,6 @@ impl Drop for MediaFormat {
     #[doc(alias = "AMediaFormat_delete")]
     fn drop(&mut self) {
         let status = unsafe { ffi::AMediaFormat_delete(self.as_ptr()) };
-        MediaError::from_status(status).unwrap()
+        MediaError::from_status(status).unwrap();
     }
 }

--- a/ndk/src/native_activity.rs
+++ b/ndk/src/native_activity.rs
@@ -235,7 +235,7 @@ impl NativeActivity {
                 self.ptr.as_ptr(),
                 add_flags.bits(),
                 remove_flags.bits(),
-            )
+            );
         }
     }
 }

--- a/ndk/src/native_activity.rs
+++ b/ndk/src/native_activity.rs
@@ -5,7 +5,7 @@
 use super::hardware_buffer_format::HardwareBufferFormat;
 use std::{
     ffi::{CStr, OsStr},
-    os::{raw::c_void, unix::prelude::OsStrExt},
+    os::{raw::c_void, unix::prelude::OsStrExt as _},
     path::Path,
     ptr::NonNull,
 };

--- a/ndk/src/performance_hint.rs
+++ b/ndk/src/performance_hint.rs
@@ -259,7 +259,7 @@ impl WorkDuration {
                     .as_nanos()
                     .try_into()
                     .expect("Supplied timestamp is too large"),
-            )
+            );
         }
     }
 
@@ -276,7 +276,7 @@ impl WorkDuration {
                     .as_nanos()
                     .try_into()
                     .expect("Supplied duration is too large"),
-            )
+            );
         }
     }
 
@@ -293,7 +293,7 @@ impl WorkDuration {
                     .as_nanos()
                     .try_into()
                     .expect("Supplied duration is too large"),
-            )
+            );
         }
     }
 
@@ -310,7 +310,7 @@ impl WorkDuration {
                     .as_nanos()
                     .try_into()
                     .expect("Supplied duration is too large"),
-            )
+            );
         }
     }
 }

--- a/ndk/src/surface_texture.rs
+++ b/ndk/src/surface_texture.rs
@@ -51,7 +51,7 @@ impl SurfaceTexture {
     pub unsafe fn from_surface_texture(env: *mut JNIEnv, surface_texture: jobject) -> Option<Self> {
         let a_surface_texture_ptr = ffi::ASurfaceTexture_fromSurfaceTexture(env, surface_texture);
         let s = NonNull::new(a_surface_texture_ptr)?;
-        Some(SurfaceTexture::from_ptr(s))
+        Some(Self::from_ptr(s))
     }
 
     /// Returns a pointer to the native [`ffi::ASurfaceTexture`].

--- a/ndk/src/sync.rs
+++ b/ndk/src/sync.rs
@@ -7,7 +7,7 @@ use std::{
     ffi::CStr,
     fmt::Debug,
     // TODO: Import from std::os::fd::{} since Rust 1.66
-    os::unix::io::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd},
+    os::unix::io::{AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd},
     ptr::NonNull,
 };
 

--- a/ndk/src/trace.rs
+++ b/ndk/src/trace.rs
@@ -24,7 +24,7 @@ impl Section {
     }
 
     pub fn end(self) {
-        drop(self)
+        drop(self);
     }
 }
 
@@ -62,7 +62,7 @@ impl AsyncSection {
     }
 
     pub fn end(self) {
-        drop(self)
+        drop(self);
     }
 }
 


### PR DESCRIPTION
- https://doc.rust-lang.org/rustdoc/lints.html#broken_intra_doc_links
- https://rust-lang.github.io/rust-clippy/rust-1.91.0/#new_without_default
- https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.UNUSED_IMPORTS.html
- https://rust-lang.github.io/rust-clippy/rust-1.91.0/#semicolon_if_nothing_returned
- https://rust-lang.github.io/rust-clippy/rust-1.91.0/#unused_trait_names
- https://rust-lang.github.io/rust-clippy/rust-1.91.0/#use_self


Fixes broken CI.

Note that fixing https://rust-lang.github.io/rust-clippy/rust-1.93.0/#mut_from_ref introduces a BC break.